### PR TITLE
Fix issue with getting task exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.2
+- [#7](https://github.com/lumoslabs/broadside/issues/7): Fix issue with getting the wrong container's exit code when running tasks
+- Bump aws-sdk version from `2.2.7` to `2.3`
+
 # 1.0.1
 - [#3](https://github.com/lumoslabs/broadside/issues/3): Fix task definition pagination
 

--- a/broadside.gemspec
+++ b/broadside.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = ['broadside']
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'aws-sdk', '~> 2.2.7'
+  spec.add_dependency 'aws-sdk', '~> 2.3'
   spec.add_dependency 'rainbow', '~> 2.1'
   spec.add_dependency 'gli', '~> 2.13'
   spec.add_dependency 'dotenv', '>= 0.9.0'

--- a/lib/broadside/version.rb
+++ b/lib/broadside/version.rb
@@ -1,3 +1,3 @@
 module Broadside
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end


### PR DESCRIPTION
Incorrectly selected first container of the task, which is not always the app container

Select the right container to modify when creating new task definitions