### PR TITLE
order of operations

### DIFF
--- a/lib/broadside/configuration/deploy_config.rb
+++ b/lib/broadside/configuration/deploy_config.rb
@@ -92,7 +92,7 @@ module Broadside
         @scale ||= @targets[@target][:scale]
         @command = @targets[@target][:command]
         @predeploy_commands = @targets[@target][:predeploy_commands] if @targets[@target][:predeploy_commands]
-        @service_config = @targets[@target][:service]
+        @service_config = @targets[@target][:service_config]
         @task_definition_config = @targets[@target][:task_definition_config]
       end
 

--- a/lib/broadside/deploy/ecs_deploy.rb
+++ b/lib/broadside/deploy/ecs_deploy.rb
@@ -185,14 +185,16 @@ module Broadside
     end
 
     def create_task_definition(name, options = {})
+      container_definition = DEFAULT_CONTAINER_DEFINITION.merge({
+        name: name,
+        command: @command,
+        environment: @deploy_config.env_vars,
+        image: image_tag,
+      })
+
       task_definition = {
         container_definitions: [
-          DEFAULT_CONTAINER_DEFINITION.merge(
-            name: name,
-            command: @command,
-            environment: @deploy_config.env_vars,
-            image: image_tag,
-          )
+          container_definition
         ],
         family: name
       }.deep_merge(options)

--- a/lib/broadside/deploy/ecs_deploy.rb
+++ b/lib/broadside/deploy/ecs_deploy.rb
@@ -185,12 +185,12 @@ module Broadside
     end
 
     def create_task_definition(name, options = {})
-      container_definition = DEFAULT_CONTAINER_DEFINITION.merge({
+      container_definition = DEFAULT_CONTAINER_DEFINITION.merge(
         name: name,
         command: @command,
         environment: @deploy_config.env_vars,
         image: image_tag,
-      })
+      )
 
       task_definition = {
         container_definitions: [
@@ -199,6 +199,7 @@ module Broadside
         family: name
       }.deep_merge(options)
 
+      puts container_definition.pretty_inspect
       puts task_definition.pretty_inspect
       ecs_client.register_task_definition(task_definition)
     end

--- a/lib/broadside/deploy/ecs_deploy.rb
+++ b/lib/broadside/deploy/ecs_deploy.rb
@@ -43,19 +43,19 @@ module Broadside
     end
 
     def bootstrap
-      unless service_exists?
-        raise ArgumentError, "Service doesn't exist and cannot be created" unless @deploy_config.service_config
-
-        info "Service #{family} doesn't exist, creating..."
-        create_service(family, @deploy_config.service_config)
-      end
-
       unless get_latest_task_def_id
         # TODO right now this creates a useless first revision and then update_task_revision will create a 2nd one
         raise ArgumentError, "No first task definition and cannot create one" unless @deploy_config.task_definition_config
 
         info "Creating an initial task definition for '#{family}' from the config..."
         create_task_definition(family, @deploy_config.task_definition_config)
+      end
+
+      unless service_exists?
+        raise ArgumentError, "Service doesn't exist and cannot be created" unless @deploy_config.service_config
+
+        info "Service '#{family}' doesn't exist, creating..."
+        create_service(family, @deploy_config.service_config)
       end
     end
 

--- a/lib/broadside/deploy/ecs_deploy.rb
+++ b/lib/broadside/deploy/ecs_deploy.rb
@@ -185,19 +185,20 @@ module Broadside
     end
 
     def create_task_definition(name, options = {})
-      ecs_client.register_task_definition(
-        {
-          container_definitions: [
-            DEFAULT_CONTAINER_DEFINITION.merge(
-              name: name,
-              command: @command,
-              environment: @deploy_config.env_vars,
-              image: image_tag,
-            )
-          ],
-          family: name
-        }.deep_merge(options)
-      )
+      task_definition = {
+        container_definitions: [
+          DEFAULT_CONTAINER_DEFINITION.merge(
+            name: name,
+            command: @command,
+            environment: @deploy_config.env_vars,
+            image: image_tag,
+          )
+        ],
+        family: name
+      }.deep_merge(options)
+
+      puts task_definition.pretty_inspect
+      ecs_client.register_task_definition(task_definition)
     end
 
     # reloads the service using the latest task definition

--- a/lib/broadside/deploy/ecs_deploy.rb
+++ b/lib/broadside/deploy/ecs_deploy.rb
@@ -185,7 +185,7 @@ module Broadside
     end
 
     def create_task_definition(name, options = {})
-      # Deep merge doesn't work with arrays
+      # Deep merge doesn't work with arrays, so build the hash and merge later
       container_definitions = DEFAULT_CONTAINER_DEFINITION.merge(
         name: name,
         command: @command,
@@ -193,11 +193,9 @@ module Broadside
         image: image_tag,
       ).merge(options[:container_definitions].first || {})
 
-      task_definition = { family: name }.deep_merge(options).merge(container_definitions: [container_definitions])
-
-      puts container_definitions.pretty_inspect
-      puts task_definition.pretty_inspect
-      ecs_client.register_task_definition(task_definition)
+      ecs_client.register_task_definition(
+        { family: name }.deep_merge(options).merge(container_definitions: [container_definitions])
+      )
     end
 
     # reloads the service using the latest task definition

--- a/lib/broadside/deploy/ecs_deploy.rb
+++ b/lib/broadside/deploy/ecs_deploy.rb
@@ -47,7 +47,7 @@ module Broadside
         # TODO right now this creates a useless first revision and then update_task_revision will create a 2nd one
         raise ArgumentError, "No first task definition and cannot create one" unless @deploy_config.task_definition_config
 
-        info "Creating an initial task definition from the config..."
+        info "Creating an initial task definition for '#{family}' from the config..."
         create_task_definition(family, @deploy_config.task_definition_config)
       end
 

--- a/spec/broadside/deploy/ecs_deploy_spec.rb
+++ b/spec/broadside/deploy/ecs_deploy_spec.rb
@@ -43,13 +43,13 @@ describe Broadside::EcsDeploy do
 
   context 'bootstrap' do
     it 'fails without service_config' do
-      expect { deploy.bootstrap }.to raise_error(/Service doesn't exist and cannot be created/)
+      expect { deploy.bootstrap }.to raise_error(/No first task definition and cannot create one/)
     end
 
     it 'fails without task_definition_config' do
-      deploy.deploy_config.service_config = service_config
+      deploy.deploy_config.task_definition_config = task_definition_config
 
-      expect { deploy.bootstrap }.to raise_error(/No first task definition and cannot create one/)
+      expect { deploy.bootstrap }.to raise_error(/Service doesn't exist and cannot be created/)
     end
 
     it 'succeeds' do


### PR DESCRIPTION
task definitions must be defined _before_ services
`container_definitions` must be handled carefully when merging