### PR TITLE
Move run, ssh, etc commands to the base of the hierarchy

### DIFF
--- a/bin/broadside
+++ b/bin/broadside
@@ -47,7 +47,7 @@ command :bootstrap do |b|
   add_shared_deploy_configs(b)
 end
 
-desc 'Deploy your application.'
+desc 'Deploy/Rollback/Scale your application. See subcommand help.'
 command :deploy do |d|
   d.desc 'Deploys without running migrations'
   d.command :short do |subcmd|
@@ -76,19 +76,6 @@ command :deploy do |d|
     add_shared_deploy_configs(subcmd)
   end
 
-  d.desc 'Creates a single instance of the application to run a command.'
-  d.command :run do |subcmd|
-    subcmd.desc 'Docker tag for application container'
-    subcmd.arg_name 'TAG'
-    subcmd.flag [:tag]
-
-    subcmd.desc 'Command to run (wrap argument in quotes)'
-    subcmd.arg_name 'COMMAND'
-    subcmd.flag [:command], type: Array
-
-    add_shared_deploy_configs(subcmd)
-  end
-
   d.desc 'Rolls back n releases and deploys'
   d.command :rollback do |subcmd|
     subcmd.desc 'Number of releases to rollback'
@@ -97,41 +84,54 @@ command :deploy do |d|
 
     add_shared_deploy_configs(subcmd)
   end
+end
 
-  d.desc 'Gets information about what is currently deployed.'
-  d.command :status do |subcmd|
-    add_shared_deploy_configs(subcmd)
-  end
+desc 'Establish a shell inside the running container.'
+command :bash do |subcmd|
+  subcmd.desc '0-based instance index'
+  subcmd.default_value 0
+  subcmd.arg_name 'INSTANCE'
+  subcmd.flag [:n, :instance], type: Fixnum
 
-  d.desc 'Tail the logs inside the running container.'
-  d.command :logtail do |subcmd|
-    subcmd.desc '0-based instance index'
-    subcmd.default_value 0
-    subcmd.arg_name 'INSTANCE'
-    subcmd.flag [:n, :instance], type: Fixnum
+  add_shared_deploy_configs(subcmd)
+end
 
-    add_shared_deploy_configs(subcmd)
-  end
+desc 'Tail the logs inside the running container.'
+command :logtail do |subcmd|
+  subcmd.desc '0-based instance index'
+  subcmd.default_value 0
+  subcmd.arg_name 'INSTANCE'
+  subcmd.flag [:n, :instance], type: Fixnum
 
-  d.desc 'Establish a secure shell on the instance running the container.'
-  d.command :ssh do |subcmd|
-    subcmd.desc '0-based instance index'
-    subcmd.default_value 0
-    subcmd.arg_name 'INSTANCE'
-    subcmd.flag [:n, :instance], type: Fixnum
+  add_shared_deploy_configs(subcmd)
+end
 
-    add_shared_deploy_configs(subcmd)
-  end
+desc 'Creates a single instance of the application to run a command.'
+command :run do |subcmd|
+  subcmd.desc 'Docker tag for application container'
+  subcmd.arg_name 'TAG'
+  subcmd.flag [:tag]
 
-  d.desc 'Establish a shell inside the running container.'
-  d.command :bash do |subcmd|
-    subcmd.desc '0-based instance index'
-    subcmd.default_value 0
-    subcmd.arg_name 'INSTANCE'
-    subcmd.flag [:n, :instance], type: Fixnum
+  subcmd.desc 'Command to run (wrap argument in quotes)'
+  subcmd.arg_name 'COMMAND'
+  subcmd.flag [:command], type: Array
 
-    add_shared_deploy_configs(subcmd)
-  end
+  add_shared_deploy_configs(subcmd)
+end
+
+desc 'Establish a secure shell on the instance running the container.'
+command :ssh do |subcmd|
+  subcmd.desc '0-based instance index'
+  subcmd.default_value 0
+  subcmd.arg_name 'INSTANCE'
+  subcmd.flag [:n, :instance], type: Fixnum
+
+  add_shared_deploy_configs(subcmd)
+end
+
+desc 'Gets information about what is currently deployed.'
+command :status do |subcmd|
+  add_shared_deploy_configs(subcmd)
 end
 
 def call_hook(type, command)

--- a/lib/broadside/deploy/ecs_deploy.rb
+++ b/lib/broadside/deploy/ecs_deploy.rb
@@ -22,7 +22,7 @@ module Broadside
 
     def deploy
       super do
-        exception "Service #{family} does not exist!" unless service_exists?
+        exception "Service #{family} does not exist!  Please bootstrap a service." unless service_exists?
         update_task_revision
 
         begin
@@ -43,16 +43,20 @@ module Broadside
     end
 
     def bootstrap
+      # Right now this creates a useless first revision and then update_task_revision will create a 2nd one
       unless get_latest_task_def_id
-        # Right now this creates a useless first revision and then update_task_revision will create a 2nd one
-        raise ArgumentError, "No first task definition and cannot create one" unless @deploy_config.task_definition_config
+        unless @deploy_config.task_definition_config
+          raise ArgumentError, "No first task definition and no :task_definition_config in '#{family}' configuration"
+        end
 
         info "Creating an initial task definition for '#{family}' from the config..."
         create_task_definition(family, @deploy_config.task_definition_config)
       end
 
       unless service_exists?
-        raise ArgumentError, "Service doesn't exist and cannot be created" unless @deploy_config.service_config
+        unless @deploy_config.service_config
+          raise ArgumentError, "Service doesn't exist and no :service_config in '#{family}' configuration"
+        end
 
         info "Service '#{family}' doesn't exist, creating..."
         create_service(family, @deploy_config.service_config)

--- a/lib/broadside/deploy/ecs_deploy.rb
+++ b/lib/broadside/deploy/ecs_deploy.rb
@@ -22,7 +22,13 @@ module Broadside
 
     def deploy
       super do
-        exception "Service #{family} does not exist!  Please bootstrap a service." unless service_exists?
+        unless service_exists?
+          exception "No service for #{family}! Please bootstrap or manually configure the service."
+        end
+        unless get_latest_task_def_id
+          exception "No task definition for '#{family}'! Please bootstrap or manually configure the task definition."
+        end
+
         update_task_revision
 
         begin

--- a/spec/broadside/deploy/ecs_deploy_spec.rb
+++ b/spec/broadside/deploy/ecs_deploy_spec.rb
@@ -76,23 +76,9 @@ describe Broadside::EcsDeploy do
       let(:task_name) { 'TEST_APP_TEST_TARGET' }
       let(:task_definition_arn) { "arn:aws:ecs:us-east-1:1234:task-definition/#{task_name}:1" }
       let(:stub_service_response) { { services: [existing_service], failures: [] } }
-      let(:stub_describe_task_definition_response) do
-        {
-          task_definition: {
-            task_definition_arn: task_definition_arn,
-            container_definitions: [
-              {
-                name: task_name
-              }
-            ],
-            family: task_name
-          }
-        }
-      end
 
       before(:each) do
         ecs_stub.stub_responses(:describe_services, stub_service_response)
-        ecs_stub.stub_responses(:describe_task_definition, stub_describe_task_definition_response)
       end
 
       it 'fails without an existing task definition' do
@@ -101,9 +87,23 @@ describe Broadside::EcsDeploy do
 
       context 'with an existing service and task_definition' do
         let(:stub_task_definition_response) { { task_definition_arns: [task_definition_arn] } }
+        let(:stub_describe_task_definition_response) do
+          {
+            task_definition: {
+              task_definition_arn: task_definition_arn,
+              container_definitions: [
+                {
+                  name: task_name
+                }
+              ],
+              family: task_name
+            }
+          }
+        end
 
         before(:each) do
           ecs_stub.stub_responses(:list_task_definitions, stub_task_definition_response)
+          ecs_stub.stub_responses(:describe_task_definition, stub_describe_task_definition_response)
         end
 
         it 'does not fail on service issues' do

--- a/spec/broadside/deploy/ecs_deploy_spec.rb
+++ b/spec/broadside/deploy/ecs_deploy_spec.rb
@@ -43,13 +43,13 @@ describe Broadside::EcsDeploy do
 
   context 'bootstrap' do
     it 'fails without service_config' do
-      expect { deploy.bootstrap }.to raise_error(/No first task definition and cannot create one/)
+      expect { deploy.bootstrap }.to raise_error(/No first task definition and no :task_definition_config/)
     end
 
     it 'fails without task_definition_config' do
       deploy.deploy_config.task_definition_config = task_definition_config
 
-      expect { deploy.bootstrap }.to raise_error(/Service doesn't exist and cannot be created/)
+      expect { deploy.bootstrap }.to raise_error(/Service doesn't exist and no :service_config /)
     end
 
     it 'succeeds' do
@@ -62,7 +62,7 @@ describe Broadside::EcsDeploy do
 
   context 'deploy' do
     it 'fails without an existing service' do
-      expect { deploy.deploy }.to raise_error(/Service TEST_APP_TEST_TARGET does not exist/)
+      expect { deploy.deploy }.to raise_error(/No service for TEST_APP_TEST_TARGET/)
     end
 
     context 'with an existing service' do

--- a/spec/broadside/deploy/ecs_deploy_spec.rb
+++ b/spec/broadside/deploy/ecs_deploy_spec.rb
@@ -76,7 +76,6 @@ describe Broadside::EcsDeploy do
       let(:task_name) { 'TEST_APP_TEST_TARGET' }
       let(:task_definition_arn) { "arn:aws:ecs:us-east-1:1234:task-definition/#{task_name}:1" }
       let(:stub_service_response) { { services: [existing_service], failures: [] } }
-      let(:stub_task_definition_response) { { task_definition_arns: [task_definition_arn] } }
       let(:stub_describe_task_definition_response) do
         {
           task_definition: {
@@ -93,14 +92,25 @@ describe Broadside::EcsDeploy do
 
       before(:each) do
         ecs_stub.stub_responses(:describe_services, stub_service_response)
-        ecs_stub.stub_responses(:list_task_definitions, stub_task_definition_response)
         ecs_stub.stub_responses(:describe_task_definition, stub_describe_task_definition_response)
       end
 
-      it 'does not fail on service issues' do
-        pending 'need to figure out how to stub a waiter, but it gets as far as update_service'
+      it 'fails without an existing task definition' do
+        expect { deploy.deploy }.to raise_error(/No task definition for/)
+      end
 
-        expect { deploy.deploy }.to_not raise_error
+      context 'with an existing service and task_definition' do
+        let(:stub_task_definition_response) { { task_definition_arns: [task_definition_arn] } }
+
+        before(:each) do
+          ecs_stub.stub_responses(:list_task_definitions, stub_task_definition_response)
+        end
+
+        it 'does not fail on service issues' do
+          pending 'need to figure out how to stub a waiter, but it gets as far as update_service'
+
+          expect { deploy.deploy }.to_not raise_error
+        end
       end
     end
   end


### PR DESCRIPTION
`deploy ssh --target my_target` makes a lot less sense than just `ssh --target my_target`

@matl33t  @rfroetscher 