### PR TITLE
Spec for the rollback method

### DIFF
--- a/spec/broadside/deploy/ecs_deploy_spec.rb
+++ b/spec/broadside/deploy/ecs_deploy_spec.rb
@@ -144,6 +144,17 @@ describe Broadside::EcsDeploy do
           service_requests = api_request_log.select { |cmd| cmd.keys.first == :update_service }
           expect(service_requests.first.values.first[:desired_count]).to eq(desired_count)
         end
+
+        it 'can rollback' do
+          expect { deploy.rollback(1) }.to_not raise_error
+          expect(api_request_log.map(&:keys).flatten).to eq([
+            :list_task_definitions,
+            :deregister_task_definition,
+            :list_task_definitions,
+            :update_service,
+            :describe_services
+          ])
+        end
       end
     end
   end


### PR DESCRIPTION
No change beyond an additional spec

also illustrates how to write specs for methods that compare the AWS call stack to an expected list of operations.  (you could also check the arguments to those methods; i didn't go all in )

@albertrdixon @matl33t 