### PR TITLE
Command to list the images deployed to all the targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.3.0
+- Add `show_images` command to display all the targets' deployed images
+
 # 1.2.1
 - [#35](https://github.com/lumoslabs/broadside/pull/35/files): Allows logtail to display more than 10 lines
 

--- a/bin/broadside
+++ b/bin/broadside
@@ -53,7 +53,7 @@ command :show_images do |show|
     _DeployObj = Kernel.const_get("Broadside::#{Broadside.config.deploy.type.capitalize}Deploy")
 
     Broadside.config.deploy.targets.each do |k, v|
-      _DeployObj.new(target: k).current_images.each do |image|
+      _DeployObj.new(target: k).current_image_info.each do |image|
         printf("%20s %20s %20s", k, image[:name], image[:image])
       end
     end

--- a/bin/broadside
+++ b/bin/broadside
@@ -54,7 +54,7 @@ command :show_images do |show|
     printf("%-40s %-50s %-25s %-10s\n", 'Target', 'Container Name', 'Image', 'Version')
 
     Broadside.config.deploy.targets.each do |k, v|
-      _DeployObj.new(target: k).current_image_info.each do |image|
+      _DeployObj.new(target: k).container_definitions.each do |image|
         image_tag, version = image[:image].split(':')
         printf("%-40s %-50s %-25s %-10s\n", k, image[:name], image_tag, version)
       end

--- a/bin/broadside
+++ b/bin/broadside
@@ -50,9 +50,12 @@ end
 desc 'List the targets and images'
 command :show_images do |show|
   show.action do |global_options, options, args|
+    _DeployObj = Kernel.const_get("Broadside::#{Broadside.config.deploy.type.capitalize}Deploy")
+
     Broadside.config.deploy.targets.each do |k, v|
-      _DeployObj = Kernel.const_get("Broadside::#{Broadside.config.deploy.type.capitalize}Deploy")
-      _DeployObj.new(target: k).current_image
+      _DeployObj.new(target: k).current_images.each do |image|
+        printf("%20s %20s %20s", k, image[:name], image[:image]
+      end
     end
   end
 end

--- a/bin/broadside
+++ b/bin/broadside
@@ -47,6 +47,7 @@ command :bootstrap do |b|
   add_shared_deploy_configs(b)
 end
 
+desc 'List the targets and images'
 command :show_images do |h|
   Broadside.config.deploy.targets.each do |k, v|
     _DeployObj = Kernel.const_get("Broadside::#{Broadside.config.deploy.type.capitalize}Deploy")

--- a/bin/broadside
+++ b/bin/broadside
@@ -51,10 +51,12 @@ desc 'List the targets and images'
 command :show_images do |show|
   show.action do |global_options, options, args|
     _DeployObj = Kernel.const_get("Broadside::#{Broadside.config.deploy.type.capitalize}Deploy")
+    printf("%40s %50s %20s %10s\n", 'Target', 'Container Name', 'Image', 'Version')
 
     Broadside.config.deploy.targets.each do |k, v|
       _DeployObj.new(target: k).current_image_info.each do |image|
-        printf("%20s %20s %20s", k, image[:name], image[:image])
+        image_tag, version = image[:image].split(':')
+        printf("%40s %50s %20s %10s\n", k, image[:name], image_tag, version)
       end
     end
   end

--- a/bin/broadside
+++ b/bin/broadside
@@ -50,7 +50,7 @@ end
 desc 'List the targets and images'
 command :show_images do |show|
   show.action do |global_options, options, args|
-    Broadside.load_config(global_options[:config])
+#    Broadside.load_config(global_options[:config])
     Broadside.config.deploy.targets.each do |k, v|
       _DeployObj = Kernel.const_get("Broadside::#{Broadside.config.deploy.type.capitalize}Deploy")
       _DeployObj.new(target: k).current_image

--- a/bin/broadside
+++ b/bin/broadside
@@ -47,6 +47,13 @@ command :bootstrap do |b|
   add_shared_deploy_configs(b)
 end
 
+command :show_images do |h|
+  Broadside.config.deploy.targets.each do |k, v|
+    _DeployObj = Kernel.const_get("Broadside::#{Broadside.config.deploy.type.capitalize}Deploy")
+    _DeployObj.new(target: k).current_image
+  end
+end
+
 desc 'Deploy your application.'
 command :deploy do |d|
   d.desc 'Deploys without running migrations'

--- a/bin/broadside
+++ b/bin/broadside
@@ -188,3 +188,4 @@ on_error do |exception|
 end
 
 exit run(ARGV)
+

--- a/bin/broadside
+++ b/bin/broadside
@@ -50,7 +50,6 @@ end
 desc 'List the targets and images'
 command :show_images do |show|
   show.action do |global_options, options, args|
-#    Broadside.load_config(global_options[:config])
     Broadside.config.deploy.targets.each do |k, v|
       _DeployObj = Kernel.const_get("Broadside::#{Broadside.config.deploy.type.capitalize}Deploy")
       _DeployObj.new(target: k).current_image

--- a/bin/broadside
+++ b/bin/broadside
@@ -51,12 +51,12 @@ desc 'List the targets and images'
 command :show_images do |show|
   show.action do |global_options, options, args|
     _DeployObj = Kernel.const_get("Broadside::#{Broadside.config.deploy.type.capitalize}Deploy")
-    printf("%40s %50s %20s %10s\n", 'Target', 'Container Name', 'Image', 'Version')
+    printf("%-40s %-50s %-25s %-10s\n", 'Target', 'Container Name', 'Image', 'Version')
 
     Broadside.config.deploy.targets.each do |k, v|
       _DeployObj.new(target: k).current_image_info.each do |image|
         image_tag, version = image[:image].split(':')
-        printf("%40s %50s %20s %10s\n", k, image[:name], image_tag, version)
+        printf("%-40s %-50s %-25s %-10s\n", k, image[:name], image_tag, version)
       end
     end
   end

--- a/bin/broadside
+++ b/bin/broadside
@@ -48,10 +48,13 @@ command :bootstrap do |b|
 end
 
 desc 'List the targets and images'
-command :show_images do |h|
-  Broadside.config.deploy.targets.each do |k, v|
-    _DeployObj = Kernel.const_get("Broadside::#{Broadside.config.deploy.type.capitalize}Deploy")
-    _DeployObj.new(target: k).current_image
+command :show_images do |show|
+  show.action do |global_options, options, args|
+    Broadside.load_config(global_options[:config])
+    Broadside.config.deploy.targets.each do |k, v|
+      _DeployObj = Kernel.const_get("Broadside::#{Broadside.config.deploy.type.capitalize}Deploy")
+      _DeployObj.new(target: k).current_image
+    end
   end
 end
 
@@ -166,7 +169,6 @@ end
 
 pre do |global, command, options, args|
   Broadside.load_config(global[:config])
-
   call_hook(:prehook, command)
   true
 end
@@ -175,7 +177,6 @@ post do |global, command, options, args|
   call_hook(:posthook, command)
   true
 end
-
 
 on_error do |exception|
   # false skips default error handling
@@ -189,4 +190,3 @@ on_error do |exception|
 end
 
 exit run(ARGV)
-

--- a/bin/broadside
+++ b/bin/broadside
@@ -54,7 +54,7 @@ command :show_images do |show|
 
     Broadside.config.deploy.targets.each do |k, v|
       _DeployObj.new(target: k).current_images.each do |image|
-        printf("%20s %20s %20s", k, image[:name], image[:image]
+        printf("%20s %20s %20s", k, image[:name], image[:image])
       end
     end
   end

--- a/lib/broadside/configuration/deploy_config.rb
+++ b/lib/broadside/configuration/deploy_config.rb
@@ -6,9 +6,7 @@ module Broadside
     class DeployConfig < ConfigStruct
       include Utils
 
-      DEFAULT_PREDEPLOY_COMMANDS = [
-        ['bundle', 'exec', 'rake', '--trace', 'db:migrate']
-      ]
+      DEFAULT_PREDEPLOY_COMMANDS = ['bundle exec rake --trace db:migrate'.split]
 
       attr_accessor(
         :type,

--- a/lib/broadside/deploy.rb
+++ b/lib/broadside/deploy.rb
@@ -82,6 +82,10 @@ module Broadside
       yield
     end
 
+    def current_image
+      yield
+    end
+
     protected
 
     def family

--- a/lib/broadside/deploy.rb
+++ b/lib/broadside/deploy.rb
@@ -82,7 +82,7 @@ module Broadside
       yield
     end
 
-    def current_image_info
+    def container_definitions
       yield
     end
 

--- a/lib/broadside/deploy.rb
+++ b/lib/broadside/deploy.rb
@@ -82,7 +82,7 @@ module Broadside
       yield
     end
 
-    def current_image
+    def current_image_info
       yield
     end
 

--- a/lib/broadside/deploy/ecs_deploy.rb
+++ b/lib/broadside/deploy/ecs_deploy.rb
@@ -131,11 +131,9 @@ module Broadside
       end
     end
 
-    def current_image_info
+    def container_definitions
       super do
-        EcsManager.get_latest_task_definition(family)[:container_definitions].map do |definition|
-          definition.slice(:name, :image)
-        end
+        EcsManager.get_latest_task_definition(family)[:container_definitions]
       end
     end
 

--- a/lib/broadside/deploy/ecs_deploy.rb
+++ b/lib/broadside/deploy/ecs_deploy.rb
@@ -131,10 +131,10 @@ module Broadside
       end
     end
 
-    def current_image
+    def current_images
       super do
-        EcsManager.get_latest_task_definition(family)[:container_definitions].each do |definition|
-          info "#{@deploy_config.target}: #{definition[:image]}"
+        EcsManager.get_latest_task_definition(family)[:container_definitions].map do |definition|
+          definition.slice(:name, :image)
         end
       end
     end

--- a/lib/broadside/deploy/ecs_deploy.rb
+++ b/lib/broadside/deploy/ecs_deploy.rb
@@ -131,6 +131,14 @@ module Broadside
       end
     end
 
+    def current_image
+      super do
+        EcsManager.get_latest_task_definition(family)[:container_definitions].each do |definition|
+          info "#{@deploy_config.target}: #{definition[:image]}"
+        end
+      end
+    end
+
     def logtail
       super do
         ip = get_running_instance_ip

--- a/lib/broadside/deploy/ecs_deploy.rb
+++ b/lib/broadside/deploy/ecs_deploy.rb
@@ -131,7 +131,7 @@ module Broadside
       end
     end
 
-    def current_images
+    def current_image_info
       super do
         EcsManager.get_latest_task_definition(family)[:container_definitions].map do |definition|
           definition.slice(:name, :image)

--- a/lib/broadside/version.rb
+++ b/lib/broadside/version.rb
@@ -1,3 +1,3 @@
 module Broadside
-  VERSION = '1.2.1'
+  VERSION = '1.3.0'
 end


### PR DESCRIPTION
We have a _lot_ of targets in EventS now, and I was curious about which versions of the image were deployed where because they are not all deployed at once... so I hacked this together.  Feel free to object to any/all of it, but this is what the output looks like:

```
Target                                   Container Name                                     Image                     Version   
adjust_events                            events_adjust_events                               spay.io/company/eventx  v0.1.168  
all_events_s3                            events_all_events_s3                               spay.io/company/eventx  v0.1.179  
<...snip...>
gamesaves_stream                         events_gamesaves_stream                            spray.io/company/eventx  v0.1.181  
```

Low priority; no one really needs this just kind of useful occasionally.