### PR TITLE
Update the task definition when running bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.4.0
+= [#42](https://github.com/lumoslabs/broadside/pull/42/files): Update the task definition when running bootstrap
+
 # 1.3.0
 - [#41](https://github.com/lumoslabs/broadside/pull/41/files): Introduce the concept of bootstrap commands, which are designed to be run when setting up a new server or environment.
 

--- a/bin/broadside
+++ b/bin/broadside
@@ -44,6 +44,10 @@ end
 
 desc 'Bootstrap your service and task definition from the configured definition.'
 command :bootstrap do |b|
+  subcmd.desc 'Docker tag for application container'
+  subcmd.arg_name 'TAG'
+  subcmd.flag [:tag]
+
   add_shared_deploy_configs(b)
 end
 

--- a/lib/broadside/deploy/ecs_deploy.rb
+++ b/lib/broadside/deploy/ecs_deploy.rb
@@ -48,7 +48,7 @@ module Broadside
     def bootstrap
       if EcsManager.get_latest_task_definition_arn(family)
         info("Task definition for #{family} already exists.")
-        run_bootstrap_commands(update_task_def: true)
+        run_bootstrap_commands
       else
         unless @deploy_config.task_definition_config
           raise ArgumentError, "No first task definition and no :task_definition_config in '#{family}' configuration"
@@ -78,13 +78,13 @@ module Broadside
       end
     end
 
-    def run_bootstrap_commands(update_task_def: false)
-      update_task_revision if update_task_def
+    def run_bootstrap_commands
+      update_task_revision
 
       begin
         @deploy_config.bootstrap_commands.each { |command| run_command(command) }
       ensure
-        EcsManager.deregister_last_n_tasks_definitions(family, 1) if update_task_def
+        EcsManager.deregister_last_n_tasks_definitions(family, 1)
       end
     end
 

--- a/lib/broadside/deploy/ecs_deploy.rb
+++ b/lib/broadside/deploy/ecs_deploy.rb
@@ -48,6 +48,7 @@ module Broadside
     def bootstrap
       if EcsManager.get_latest_task_definition_arn(family)
         info("Task definition for #{family} already exists.")
+        run_bootstrap_commands(update_revision: true)
       else
         unless @deploy_config.task_definition_config
           raise ArgumentError, "No first task definition and no :task_definition_config in '#{family}' configuration"
@@ -61,6 +62,8 @@ module Broadside
             container_definitions: [DEFAULT_CONTAINER_DEFINITION.merge(container_definition)]
           )
         )
+
+        run_bootstrap_commands
       end
 
       if EcsManager.service_exists?(config.ecs.cluster, family)
@@ -73,8 +76,16 @@ module Broadside
         info "Service '#{family}' doesn't exist, creating..."
         EcsManager.create_service(config.ecs.cluster, family, @deploy_config.service_config)
       end
+    end
 
-      @deploy_config.bootstrap_commands.each { |command| run_command(command) }
+    def run_bootstrap_commands(update_revision: false)
+      update_task_revision if update_revision
+
+      begin
+        @deploy_config.bootstrap_commands.each { |command| run_command(command) }
+      ensure
+        EcsManager.deregister_last_n_tasks_definitions(family, 1) if update_revision
+      end
     end
 
     def rollback(count = @deploy_config.rollback)

--- a/lib/broadside/deploy/ecs_deploy.rb
+++ b/lib/broadside/deploy/ecs_deploy.rb
@@ -48,7 +48,7 @@ module Broadside
     def bootstrap
       if EcsManager.get_latest_task_definition_arn(family)
         info("Task definition for #{family} already exists.")
-        run_bootstrap_commands(update_revision: true)
+        run_bootstrap_commands(update_task_def: true)
       else
         unless @deploy_config.task_definition_config
           raise ArgumentError, "No first task definition and no :task_definition_config in '#{family}' configuration"
@@ -78,13 +78,13 @@ module Broadside
       end
     end
 
-    def run_bootstrap_commands(update_revision: false)
-      update_task_revision if update_revision
+    def run_bootstrap_commands(update_task_def: false)
+      update_task_revision if update_task_def
 
       begin
         @deploy_config.bootstrap_commands.each { |command| run_command(command) }
       ensure
-        EcsManager.deregister_last_n_tasks_definitions(family, 1) if update_revision
+        EcsManager.deregister_last_n_tasks_definitions(family, 1) if update_task_def
       end
     end
 

--- a/lib/broadside/version.rb
+++ b/lib/broadside/version.rb
@@ -1,3 +1,3 @@
 module Broadside
-  VERSION = '1.3.0'
+  VERSION = '1.4.0'
 end

--- a/spec/broadside/deploy/ecs_deploy_spec.rb
+++ b/spec/broadside/deploy/ecs_deploy_spec.rb
@@ -87,38 +87,43 @@ describe Broadside::EcsDeploy do
       expect { deploy.bootstrap }.to raise_error(//)
     end
 
-    it 'fails without service_config' do
-      deploy.deploy_config.task_definition_config = task_definition_config
-
-      expect { deploy.bootstrap }.to raise_error(/Service doesn't exist and no :service_config/)
-    end
-
-    context 'with an existing task definition and service' do
+    context 'with an existing task definition' do
       before(:each) do
         ecs_stub.stub_responses(:list_task_definitions, stub_task_definition_response)
         ecs_stub.stub_responses(:describe_task_definition, stub_describe_task_definition_response)
-        ecs_stub.stub_responses(:describe_services, stub_service_response)
       end
 
-      it 'succeeds' do
-        deploy.deploy_config.service_config = service_config
+      it 'fails without service_config' do
         deploy.deploy_config.task_definition_config = task_definition_config
 
-        expect { deploy.bootstrap }.to_not raise_error
+        expect { deploy.bootstrap }.to raise_error(/Service doesn't exist and no :service_config/)
       end
 
-      context 'and some configured bootstrap commands' do
-        before do
-          Broadside.configure do |config|
-            config.deploy.targets[task_name.to_sym][:bootstrap_commands] = [
-              %w(foo bar baz)
-            ]
-          end
+      context 'with an existing service' do
+        before(:each) do
+          ecs_stub.stub_responses(:describe_services, stub_service_response)
         end
 
-        it 'runs bootstrap commands' do
-          expect(deploy).to receive(:run_command).with(%w(foo bar baz))
-          deploy.bootstrap
+        it 'succeeds' do
+          deploy.deploy_config.service_config = service_config
+          deploy.deploy_config.task_definition_config = task_definition_config
+
+          expect { deploy.bootstrap }.to_not raise_error
+        end
+
+        context 'and some configured bootstrap commands' do
+          before do
+            Broadside.configure do |config|
+              config.deploy.targets[task_name.to_sym][:bootstrap_commands] = [
+                %w(foo bar baz)
+              ]
+            end
+          end
+
+          it 'runs bootstrap commands' do
+            expect(deploy).to receive(:run_command).with(%w(foo bar baz))
+            deploy.bootstrap
+          end
         end
       end
     end


### PR DESCRIPTION
I ran into a couple of edge cases when running the `bootstrap` command on our new dockerized staging servers:

1. I initially provided some incorrect configuration in the form of environment variables, which were added to the initial task definition. I tried running `bootstrap` a second time, but because the task definition doesn't get updated on bootstrap, it failed a second time.
2. I wanted to run `bootstrap` with a different docker tag than the default, which the command doesn't currently support.

This PR fixes both issues.