### PR TITLE
Move ssh, bash, logtail, status, and run out of the deploy command hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.0.0
+- **BREAKING CHANGE**: `ssh`, `bash`, `logtail`, `status`, and `run` are now top level commands, not subcommands of `deploy`
+- **BREAKING CHANGE**: `config.git_repo` was removed.  `config.base` and `config.deploy` also are no longer backwards compatible
+
 # 2.0.0
 - **BREAKING CHANGE**: `rake db:migrate` is no longer the default `predeploy_command`
 - *NEW FEATURE*: `:cluster` can be configured on a per target basis to overload `config.ecs.cluster`

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Broadside offers a simple command-line interface to perform deployments on ECS. 
 Broadside.configure do |config|
   config.application = 'hello_world'
   config.docker_image = 'lumoslabs/hello_world'
-  config.type = 'ecs'
   config.ecs.cluster = 'micro-cluster'
   config.deploy.targets = {
     production_web: {

--- a/bin/broadside
+++ b/bin/broadside
@@ -141,7 +141,7 @@ command :bash do |bash|
 end
 
 def call_hook(type, command)
-  hook = Broadside.config.send(type)
+  hook = Broadside.config.public_send(type)
 
   if hook.is_a?(Proc)
     hook_args =

--- a/bin/broadside
+++ b/bin/broadside
@@ -20,7 +20,7 @@ arg_name 'FILE'
 flag [:c, :config]
 
 def add_target_configs(subcmd)
-  # deployment always requires target
+  # Everything requires a target
   subcmd.desc 'Deployment target to use, e.g. production_web'
   subcmd.arg_name 'TARGET'
   subcmd.flag [:t, :target], type: Symbol

--- a/bin/broadside
+++ b/bin/broadside
@@ -33,6 +33,16 @@ def add_target_configs(subcmd)
   end
 end
 
+# Commands like bash, ssh, and logtail require an instance
+def add_instance_config(cmd)
+  cmd.desc '0-based index into the array of running instances'
+  cmd.default_value 0
+  cmd.arg_name 'INSTANCE'
+  cmd.flag [:n, :instance], type: Fixnum
+
+  add_target_configs(cmd)
+end
+
 # GLI type coercions
 accept Symbol do |val|
   val.to_sym
@@ -110,39 +120,24 @@ command :run do |run|
   add_target_configs(run)
 end
 
-desc 'Tail the logs inside the running container.'
+desc 'Tail the logs inside a running container.'
 command :logtail do |logtail|
-  logtail.desc '0-based instance index'
-  logtail.default_value 0
-  logtail.arg_name 'INSTANCE'
-  logtail.flag [:n, :instance], type: Fixnum
-
   logtail.desc 'Number of lines to tail'
   logtail.default_value 10
   logtail.arg_name 'TAIL_LINES'
   logtail.flag [:l, :lines], type: Fixnum
 
-  add_target_configs(logtail)
+  add_instance_config(logtail)
 end
 
-desc 'Establish a secure shell on the instance running the container.'
+desc 'Establish a secure shell on an instance running the container.'
 command :ssh do |ssh|
-  ssh.desc '0-based instance index'
-  ssh.default_value 0
-  ssh.arg_name 'INSTANCE'
-  ssh.flag [:n, :instance], type: Fixnum
-
-  add_target_configs(ssh)
+  add_instance_config(ssh)
 end
 
-desc 'Establish a shell inside the running container.'
+desc 'Establish a shell inside a running container.'
 command :bash do |bash|
-  bash.desc '0-based instance index'
-  bash.default_value 0
-  bash.arg_name 'INSTANCE'
-  bash.flag [:n, :instance], type: Fixnum
-
-  add_target_configs(bash)
+  add_instance_config(bash)
 end
 
 def call_hook(type, command)

--- a/bin/broadside
+++ b/bin/broadside
@@ -90,11 +90,11 @@ command :deploy do |d|
 
     add_target_configs(rollback)
   end
+end
 
-  desc 'Gets information about what is currently deployed.'
-  d.command :status do |status|
-    add_target_configs(status)
-  end
+desc 'Gets information about what is currently deployed.'
+command :status do |status|
+  add_target_configs(status)
 end
 
 desc 'Creates a single instance of the application to run a command.'

--- a/bin/broadside
+++ b/bin/broadside
@@ -104,7 +104,6 @@ command :run do |run|
   add_target_configs(run)
 end
 
-command
 desc 'Tail the logs inside the running container.'
 command :logtail do |logtail|
   logtail.desc '0-based instance index'
@@ -168,7 +167,6 @@ post do |global, command, options, args|
   call_hook(:posthook, command)
   true
 end
-
 
 on_error do |exception|
   # false skips default error handling

--- a/bin/broadside
+++ b/bin/broadside
@@ -34,9 +34,15 @@ def add_target_configs(subcmd)
 end
 
 # GLI type coercions
-accept Symbol { |val| val.to_sym }
-accept Array  { |val| val.split(' ') }
-accept Fixnum { |val| val.to_i }
+accept Symbol do |val|
+  val.to_sym
+end
+accept Array do |val|
+  val.split(' ')
+end
+accept Fixnum do |val|
+  val.to_i
+end
 
 desc 'Bootstrap your service and task definition from the configured definition.'
 command :bootstrap do |bootstrap|

--- a/bin/broadside
+++ b/bin/broadside
@@ -19,7 +19,7 @@ default_value 'config/broadside.conf.rb'
 arg_name 'FILE'
 flag [:c, :config]
 
-def add_shared_deploy_configs(subcmd)
+def add_target_configs(subcmd)
   # deployment always requires target
   subcmd.desc 'Deployment target to use, e.g. production_web'
   subcmd.arg_name 'TARGET'
@@ -28,121 +28,116 @@ def add_shared_deploy_configs(subcmd)
   subcmd.action do |global_options, options, args|
     _DeployObj = Kernel.const_get("Broadside::#{Broadside.config.type.capitalize}Deploy")
     _target = Broadside.config.targets.select { |t| t.name == options[:target] }.first
-    raise "Bad target: #{options[:target]}" unless _target
+    raise "Target ':#{options[:target]}' not configured. " unless _target
     _DeployObj.new(_target, options).public_send(subcmd.name)
   end
 end
 
 # GLI type coercions
-accept Symbol do |val|
-  val.to_sym
-end
-accept Array do |val|
-  val.split(' ')
-end
-accept Fixnum do |val|
-  val.to_i
-end
+accept Symbol { |val| val.to_sym }
+accept Array  { |val| val.split(' ') }
+accept Fixnum { |val| val.to_i }
 
 desc 'Bootstrap your service and task definition from the configured definition.'
-command :bootstrap do |b|
-  b.desc 'Docker tag for application container'
-  b.arg_name 'TAG'
-  b.flag [:tag]
+command :bootstrap do |bootstrap|
+  bootstrap.desc 'Docker tag for application container'
+  bootstrap.arg_name 'TAG'
+  bootstrap.flag [:tag]
 
-  add_shared_deploy_configs(b)
+  add_target_configs(bootstrap)
 end
 
 desc 'Deploy your application.'
 command :deploy do |d|
-  d.desc 'Deploys without running migrations'
-  d.command :short do |subcmd|
-    subcmd.desc 'Docker tag for application container'
-    subcmd.arg_name 'TAG'
-    subcmd.flag [:tag]
+  d.desc 'Deploys WITHOUT running predeploy commands'
+  d.command :short do |short|
+    short.desc 'Docker tag for application container'
+    short.arg_name 'TAG'
+    short.flag [:tag]
 
-    add_shared_deploy_configs(subcmd)
+    add_target_configs(short)
   end
 
-  d.desc 'Performs a full deployment (with migration)'
-  d.command :full do |subcmd|
-    subcmd.desc 'Docker tag for application container'
-    subcmd.arg_name 'TAG'
-    subcmd.flag [:tag]
+  d.desc 'Deploys WITH running predeploy commands'
+  d.command :full do |full|
+    full.desc 'Docker tag for application container'
+    full.arg_name 'TAG'
+    full.flag [:tag]
 
-    add_shared_deploy_configs(subcmd)
+    add_target_configs(full)
   end
 
   d.desc 'Scales application to a given count'
-  d.command :scale do |subcmd|
-    subcmd.desc 'Specify a new scale for application'
-    subcmd.arg_name 'NUM'
-    subcmd.flag [:s, :scale], type: Fixnum
+  d.command :scale do |scale|
+    scale.desc 'Specify a new scale for application'
+    scale.arg_name 'NUM'
+    scale.flag [:s, :scale], type: Fixnum
 
-    add_shared_deploy_configs(subcmd)
-  end
-
-  d.desc 'Creates a single instance of the application to run a command.'
-  d.command :run do |subcmd|
-    subcmd.desc 'Docker tag for application container'
-    subcmd.arg_name 'TAG'
-    subcmd.flag [:tag]
-
-    subcmd.desc 'Command to run (wrap argument in quotes)'
-    subcmd.arg_name 'COMMAND'
-    subcmd.flag [:command], type: Array
-
-    add_shared_deploy_configs(subcmd)
+    add_target_configs(scale)
   end
 
   d.desc 'Rolls back n releases and deploys'
-  d.command :rollback do |subcmd|
-    subcmd.desc 'Number of releases to rollback'
-    subcmd.arg_name 'COUNT'
-    subcmd.flag [:r, :rollback], type: Fixnum
+  d.command :rollback do |rollback|
+    rollback.desc 'Number of releases to rollback'
+    rollback.arg_name 'COUNT'
+    rollback.flag [:r, :rollback], type: Fixnum
 
-    add_shared_deploy_configs(subcmd)
+    add_target_configs(rollback)
   end
 
-  d.desc 'Gets information about what is currently deployed.'
-  d.command :status do |subcmd|
-    add_shared_deploy_configs(subcmd)
+  desc 'Gets information about what is currently deployed.'
+  d.command :status do |status|
+    add_target_configs(status)
   end
+end
 
-  d.desc 'Tail the logs inside the running container.'
-  d.command :logtail do |subcmd|
-    subcmd.desc '0-based instance index'
-    subcmd.default_value 0
-    subcmd.arg_name 'INSTANCE'
-    subcmd.flag [:n, :instance], type: Fixnum
+desc 'Creates a single instance of the application to run a command.'
+command :run do |run|
+  run.desc 'Docker tag for application container'
+  run.arg_name 'TAG'
+  run.flag [:tag]
 
-    subcmd.desc 'Number of lines to tail'
-    subcmd.default_value 10
-    subcmd.arg_name 'TAIL_LINES'
-    subcmd.flag [:l, :lines], type: Fixnum
+  run.desc 'Command to run (wrap argument in quotes)'
+  run.arg_name 'COMMAND'
+  run.flag [:command], type: Array
 
-    add_shared_deploy_configs(subcmd)
-  end
+  add_target_configs(run)
+end
 
-  d.desc 'Establish a secure shell on the instance running the container.'
-  d.command :ssh do |subcmd|
-    subcmd.desc '0-based instance index'
-    subcmd.default_value 0
-    subcmd.arg_name 'INSTANCE'
-    subcmd.flag [:n, :instance], type: Fixnum
+command
+desc 'Tail the logs inside the running container.'
+command :logtail do |logtail|
+  logtail.desc '0-based instance index'
+  logtail.default_value 0
+  logtail.arg_name 'INSTANCE'
+  logtail.flag [:n, :instance], type: Fixnum
 
-    add_shared_deploy_configs(subcmd)
-  end
+  logtail.desc 'Number of lines to tail'
+  logtail.default_value 10
+  logtail.arg_name 'TAIL_LINES'
+  logtail.flag [:l, :lines], type: Fixnum
 
-  d.desc 'Establish a shell inside the running container.'
-  d.command :bash do |subcmd|
-    subcmd.desc '0-based instance index'
-    subcmd.default_value 0
-    subcmd.arg_name 'INSTANCE'
-    subcmd.flag [:n, :instance], type: Fixnum
+  add_target_configs(logtail)
+end
 
-    add_shared_deploy_configs(subcmd)
-  end
+desc 'Establish a secure shell on the instance running the container.'
+command :ssh do |ssh|
+  ssh.desc '0-based instance index'
+  ssh.default_value 0
+  ssh.arg_name 'INSTANCE'
+  ssh.flag [:n, :instance], type: Fixnum
+
+  add_target_configs(ssh)
+end
+
+desc 'Establish a shell inside the running container.'
+command :bash do |bash|
+  bash.desc '0-based instance index'
+  bash.default_value 0
+  bash.arg_name 'INSTANCE'
+  bash.flag [:n, :instance], type: Fixnum
+
+  add_target_configs(bash)
 end
 
 def call_hook(type, command)
@@ -165,7 +160,6 @@ end
 
 pre do |global, command, options, args|
   Broadside.load_config(global[:config])
-
   call_hook(:prehook, command)
   true
 end

--- a/broadside.gemspec
+++ b/broadside.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '>= 3', '< 5'
   spec.add_dependency 'aws-sdk', '~> 2.3'
-  spec.add_dependency 'dotenv', '>= 0.9.0'
+  spec.add_dependency 'dotenv', '>= 0.9.0', '< 3.0'
   spec.add_dependency 'gli', '~> 2.13'
   spec.add_dependency 'rainbow', '~> 2.1'
 
   spec.add_development_dependency 'rspec', '~> 3.4.0'
   spec.add_development_dependency 'bundler', '~> 1.9'
-  spec.add_development_dependency 'fakefs'
+  spec.add_development_dependency 'fakefs', '~> 0.9'
 end

--- a/lib/broadside.rb
+++ b/lib/broadside.rb
@@ -14,7 +14,7 @@ require 'broadside/version'
 module Broadside
   extend Utils
 
-  SYSTEM_CONFIG_FILE = "#{Dir.home}/.broadside/config.rb"
+  USER_CONFIG_FILE = "#{Dir.home}/.broadside/config.rb"
 
   def self.configure
     yield config
@@ -22,14 +22,14 @@ module Broadside
 
   def self.load_config(config_file)
     begin
-      load SYSTEM_CONFIG_FILE if File.exists?(SYSTEM_CONFIG_FILE)
+      load USER_CONFIG_FILE if File.exists?(USER_CONFIG_FILE)
     rescue LoadError => e
-      error "Encountered an error loading system configuration file '#{SYSTEM_CONFIG_FILE}' !"
+      error "Encountered an error loading system configuration file '#{USER_CONFIG_FILE}' !"
       raise e
     end
 
     begin
-      config.file = config_file
+      config.config_file = config_file
       load config_file
     rescue LoadError => e
       error "Encountered an error loading required configuration file '#{config_file}' !"

--- a/lib/broadside/configuration.rb
+++ b/lib/broadside/configuration.rb
@@ -43,20 +43,5 @@ module Broadside
     def verify(*args)
       super(*([:application, :docker_image] + args))
     end
-
-    def git_repo=(_)
-      @logger.warn("Assigning :git_repo does nothing.")
-    end
-
-    # Maintain backward compatibility
-    def deploy
-      self
-    end
-    deprecate :deploy, 'config.deploy.option should be configured directly as config.option', 2017, 4
-
-    def base
-      self
-    end
-    deprecate :base, 'config.base.option should be configured directly as config.option', 2017, 4
   end
 end

--- a/lib/broadside/configuration.rb
+++ b/lib/broadside/configuration.rb
@@ -24,6 +24,7 @@ module Broadside
       @logger.level = ::Logger::DEBUG
       @logger.datetime_format = '%Y-%m-%d_%H:%M:%S'
       @timeout = 600
+      @type = 'ecs'
     end
 
     def aws

--- a/lib/broadside/configuration.rb
+++ b/lib/broadside/configuration.rb
@@ -6,11 +6,11 @@ module Broadside
     include VerifyInstanceVariables
     include Utils
 
+    attr_reader :targets
     attr_accessor(
       :application,
+      :config_file,
       :docker_image,
-      :file,
-      :git_repo,
       :logger,
       :prehook,
       :posthook,
@@ -18,7 +18,6 @@ module Broadside
       :timeout,
       :type
     )
-    attr_reader :targets
 
     def initialize
       @logger = ::Logger.new(STDOUT)
@@ -42,6 +41,10 @@ module Broadside
 
     def verify(*args)
       super(*([:application, :docker_image] + args))
+    end
+
+    def git_repo=
+      @logger.warn("Assigning :git_repo does nothing.")
     end
 
     # Maintain backward compatibility

--- a/lib/broadside/configuration.rb
+++ b/lib/broadside/configuration.rb
@@ -43,7 +43,7 @@ module Broadside
       super(*([:application, :docker_image] + args))
     end
 
-    def git_repo=
+    def git_repo=(_)
       @logger.warn("Assigning :git_repo does nothing.")
     end
 

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -190,7 +190,7 @@ module Broadside
         seen_event = nil
 
         w.before_wait do |attempt, response|
-          debug "(#{attempt}/#{w.max_attempts ? w.max_attempt : Float::INFINITY}) Polling ECS for events..."
+          debug "(#{attempt}/#{w.max_attempts ? w.max_attempts : Float::INFINITY}) Polling ECS for events..."
           # skip first event since it doesn't apply to current request
           if response.services[0].events.first && response.services[0].events.first.id != seen_event && attempt > 1
             seen_event = response.services[0].events.first.id

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -263,7 +263,7 @@ module Broadside
         raise ArgumentError, 'Creating > 1 container definition not supported yet'
       end
 
-      (configured_containers.first || {}).merge(
+      (configured_containers.try(:first) || {}).merge(
         name: family,
         command: @command,
         environment: @target.env_vars,

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -258,11 +258,12 @@ module Broadside
 
     def container_definition
       configured_containers = (@target.task_definition_config || {})[:container_definitions]
+
       if configured_containers && configured_containers.size > 1
         raise ArgumentError, 'Creating > 1 container definition not supported yet'
       end
 
-      (configured_containers.try(:first) || {}).merge(
+      (configured_containers.first || {}).merge(
         name: family,
         command: @command,
         environment: @target.env_vars,

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -190,7 +190,7 @@ module Broadside
         seen_event = nil
 
         w.before_wait do |attempt, response|
-          debug "(#{attempt}/#{w.max_attempts}) Polling ECS for events..."
+          debug "(#{attempt}/#{w.max_attempts ? w.max_attempt : Float::INFINITY}) Polling ECS for events..."
           # skip first event since it doesn't apply to current request
           if response.services[0].events.first && response.services[0].events.first.id != seen_event && attempt > 1
             seen_event = response.services[0].events.first.id

--- a/lib/broadside/target.rb
+++ b/lib/broadside/target.rb
@@ -16,7 +16,6 @@ module Broadside
       :predeploy_commands,
       :scale,
       :service_config,
-      :tag,
       :task_definition_config
     )
 
@@ -26,7 +25,7 @@ module Broadside
       @name = name
       @config = options
 
-      @bootstrap_commands = @config[:bootstrap_commands] || []
+      @bootstrap_commands = @config[:bootstrap_commands]
       @cluster = @config[:cluster]
       @command = @config[:command]
       _env_files = @config[:env_files] || @config[:env_file]
@@ -36,7 +35,6 @@ module Broadside
       @predeploy_commands = @config[:predeploy_commands]
       @scale = @config[:scale]
       @service_config = @config[:service_config]
-      @tag = @config[:tag]
       @task_definition_config = @config[:task_definition_config]
 
       validate!

--- a/spec/broadside_spec.rb
+++ b/spec/broadside_spec.rb
@@ -10,7 +10,7 @@ describe Broadside do
       allow(Broadside).to receive(:load)
       # stub out verify from erroring since load is stubbed
       allow(Broadside.config).to receive(:verify)
-      stub_const('Broadside::SYSTEM_CONFIG_FILE', system_config_path)
+      stub_const('Broadside::USER_CONFIG_FILE', system_config_path)
       Broadside.load_config(app_config_path)
       expect(Broadside).to have_received(:load).with(system_config_path)
     end
@@ -19,7 +19,7 @@ describe Broadside do
       allow(Broadside).to receive(:load)
       # stub out verify from erroring since load is stubbed
       allow(Broadside.config).to receive(:verify)
-      stub_const('Broadside::SYSTEM_CONFIG_FILE', bad_path)
+      stub_const('Broadside::USER_CONFIG_FILE', bad_path)
       Broadside.load_config(app_config_path)
       expect(Broadside).not_to have_received(:load).with(bad_path)
     end

--- a/spec/fixtures/configuration_examples.rb
+++ b/spec/fixtures/configuration_examples.rb
@@ -3,7 +3,7 @@ shared_context 'base configuration' do
 
   before(:each) do
     Broadside.configure do |c|
-      c.file = __FILE__
+      c.config_file = __FILE__
       c.application = test_app
       c.docker_image = 'rails'
       c.logger.level = Logger::ERROR


### PR DESCRIPTION
Also:

- remove `:git_repo` config - unless i missed something it is not used anywhere in the code.
- rename `config.file` to `config.config_file` - i found this confusing
- display `Infinity` when polling forever instead of nothing
- default to `'ecs'` as a type until we have an actual non ECS option

not sure what version number to use here - i guess technically we should do 3.0.