### PR TITLE
Print (a lot) more status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Only load `env_files` for the selected target (AKA don't preload everything when you aren't using it)
 - Make `env_files` configuration optional
 - No more `Utils` module, just `LoggingUtils`
-- Exceptions will be raised if you try to configure a target with an invalid hash key
+- Exceptions will be raised if you try to configure a `Target` with an invalid hash key
 - `broadside status` shows you a lot more stuff
 
 # 2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Make `env_files` configuration optional
 - No more `Utils` module, just `LoggingUtils`
 - Exceptions will be raised if you try to configure a target with an invalid hash key
+- `broadside status` shows you a lot more stuff
 
 # 2.0.0
 - **BREAKING CHANGE**: `rake db:migrate` is no longer the default `predeploy_command`

--- a/bin/broadside
+++ b/bin/broadside
@@ -68,18 +68,22 @@ desc 'List the targets and deployed images'
 command :list_targets do |list_targets|
   list_targets.action do |global_options, options, args|
     _DeployObj = Kernel.const_get("Broadside::#{Broadside.config.type.capitalize}Deploy")
-    printf("%-40s %-50s %-25s %-10s %-5s %-7s %-1s %-9s %-23s\n", 'Target', 'Container Name', 'Image', 'Version', 'CPU', 'Memory', '#', 'Status', 'Started')
+    printf("%-50s %-25s %-10s %-5s %-6s %-1s %-9s %-23s\n", 'Container Name', 'Image', 'Version', 'CPU', 'Memory', '#', 'Status', 'Started')
 
     Broadside.config.targets.each do |target|
       deploy = _DeployObj.new(target)
-      container_definitions = Broadside::EcsManager.get_latest_task_definition(deploy.family)[:container_definitions]
-      container_definitions.each do |image|
+      task_definition = Broadside::EcsManager.get_latest_task_definition(deploy.family)
+      if task_definition.nil?
+        puts "#{target.name} has no task_definition in place"
+        next
+      end
+
+      task_definition[:container_definitions].each do |image|
         image_tag, version = image[:image].split(':')
         task_arns = Broadside::EcsManager.get_task_arns(target.cluster, deploy.family)
         Broadside::EcsManager.ecs.describe_tasks(cluster: target.cluster, tasks: task_arns).tasks.each_with_index do |task, i|
           printf(
-            "%-40s %-50s %-25s %-10s %-5s %-7s %-1d %-9s %-23s\n",
-            target.name,
+            "%-50s %-25s %-10s %-5s %-6s %-1d %-9s %-23s\n",
             image[:name],
             image_tag,
             version,

--- a/bin/broadside
+++ b/bin/broadside
@@ -68,7 +68,7 @@ desc 'List the targets and deployed images'
 command :list_targets do |list_targets|
   list_targets.action do |global_options, options, args|
     _DeployObj = Kernel.const_get("Broadside::#{Broadside.config.type.capitalize}Deploy")
-    printf("%-50s %-25s %-10s %-5s %-6s %-1s %-9s %-23s\n", 'Container Name', 'Image', 'Version', 'CPU', 'Memory', '#', 'Status', 'Started')
+    printf("%-50s %-25s %-10s %-5s %-6s %-1s %-9s %-23s\n", 'Target', 'Image', 'Version', 'CPU', 'Memory', '#', 'Status', 'Started')
 
     Broadside.config.targets.each do |target|
       deploy = _DeployObj.new(target)
@@ -84,7 +84,7 @@ command :list_targets do |list_targets|
         Broadside::EcsManager.ecs.describe_tasks(cluster: target.cluster, tasks: task_arns).tasks.each_with_index do |task, i|
           printf(
             "%-50s %-25s %-10s %-5s %-6s %-1d %-9s %-23s\n",
-            image[:name],
+            target.name,
             image_tag,
             version,
             image[:cpu],

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -104,6 +104,11 @@ module Broadside
       super do
         ips = EcsManager.get_running_instance_ips(@target.cluster, family)
         task_arns = Broadside::EcsManager.get_task_arns(@target.cluster, family)
+        tasks = if task_arns.nil? || task_arns.empty?
+                  'None'
+                else
+                  Broadside::EcsManager.ecs.describe_tasks(cluster: @target.cluster, tasks: task_arns)
+                end
 
         info "\n---------------\n",
           Rainbow("Current task definition information:\n").underline,
@@ -113,13 +118,10 @@ module Broadside
           Rainbow(PP.pp(EcsManager.ecs.describe_services(cluster: @target.cluster, services: [family]), '')).aliceblue,
           "\n",
           Rainbow("Task information:\n").underline,
-          Rainbow(PP.pp(Broadside::EcsManager.ecs.describe_tasks(cluster: @target.cluster, tasks: task_arns), '')).aqua,
-          "\n",
-          Rainbow("Private ips of instances running containers:\n").underline,
-          Rainbow(ips.join(' ')).blue,
+          Rainbow(PP.pp(tasks, '')).aqua,
           "\n\n",
-          Rainbow("ssh command:\n").underline,
-          Rainbow(gen_ssh_cmd(ips.first)).cyan,
+          Rainbow("IPs and SSH commands:\n").underline,
+          Rainbow(ips.map { |ip| "#{ip} #{gen_ssh_cmd(ip)}"}.join("\n")).cyan,
           "\n"
       end
     end

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -5,6 +5,7 @@ require 'shellwords'
 
 module Broadside
   class EcsDeploy < Deploy
+    WIDTH = 150
     DEFAULT_CONTAINER_DEFINITION = {
       cpu: 1,
       essential: true,
@@ -108,13 +109,13 @@ module Broadside
 
         info "\n---------------\n",
           Rainbow("Current task definition information:\n").underline,
-          Rainbow(PP.pp(EcsManager.get_latest_task_definition(family), '')).blue,
+          Rainbow(PP.pp(EcsManager.get_latest_task_definition(family), '', WIDTH)).blue,
           "\n",
           Rainbow("Current service information:\n").underline,
-          Rainbow(PP.pp(EcsManager.ecs.describe_services(cluster: @target.cluster, services: [family]).to_hash, '')).aliceblue,
+          Rainbow(PP.pp(EcsManager.ecs.describe_services(cluster: @target.cluster, services: [family]).to_hash, '', WIDTH)).aliceblue,
           "\n",
           Rainbow("Task information:\n").underline,
-          Rainbow(PP.pp(tasks, '')).aqua,
+          Rainbow(PP.pp(tasks, '', WIDTH)).aqua,
           "\n\n",
           Rainbow("IPs and SSH commands:\n").underline,
           Rainbow(ips.map { |ip| "#{ip}: #{gen_ssh_cmd(ip)}"}.join("\n")).cyan,

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -103,13 +103,24 @@ module Broadside
     def status
       super do
         ips = EcsManager.get_running_instance_ips(@target.cluster, family)
-        info "\n---------------",
-          "\nDeployed task definition information:\n",
+        task_arns = Broadside::EcsManager.get_task_arns(cluster, family)
+
+        info "\n---------------\n",
+          Rainbow("Current task definition information:\n").underline,
           Rainbow(PP.pp(EcsManager.get_latest_task_definition(family), '')).blue,
-          "\nPrivate ips of instances running containers:\n",
+          "\n",
+          Rainbow("Current service information:\n").underline,
+          Rainbow(PP.pp(EcsManager.ecs.describe_services(cluster: cluster, services: [family]), '')).aliceblue,
+          "\n",
+          Rainbow("Task information:\n").underline,
+          Rainbow(PP.pp(Broadside::EcsManager.ecs.describe_tasks(cluster: cluster, tasks: task_arns), '')).aqua,
+          "\n",
+          Rainbow("Private ips of instances running containers:\n").underline,
           Rainbow(ips.join(' ')).blue,
-          "\n\nssh command:\n#{Rainbow(gen_ssh_cmd(ips.first)).cyan}",
-          "\n---------------\n"
+          "\n\n",
+          Rainbow("ssh command:").underline,
+          Rainbow(gen_ssh_cmd(ips.first)).cyan,
+          "\n"
       end
     end
 

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -103,17 +103,17 @@ module Broadside
     def status
       super do
         ips = EcsManager.get_running_instance_ips(@target.cluster, family)
-        task_arns = Broadside::EcsManager.get_task_arns(cluster, family)
+        task_arns = Broadside::EcsManager.get_task_arns(@target.cluster, family)
 
         info "\n---------------\n",
           Rainbow("Current task definition information:\n").underline,
           Rainbow(PP.pp(EcsManager.get_latest_task_definition(family), '')).blue,
           "\n",
           Rainbow("Current service information:\n").underline,
-          Rainbow(PP.pp(EcsManager.ecs.describe_services(cluster: cluster, services: [family]), '')).aliceblue,
+          Rainbow(PP.pp(EcsManager.ecs.describe_services(cluster: @target.cluster, services: [family]), '')).aliceblue,
           "\n",
           Rainbow("Task information:\n").underline,
-          Rainbow(PP.pp(Broadside::EcsManager.ecs.describe_tasks(cluster: cluster, tasks: task_arns), '')).aqua,
+          Rainbow(PP.pp(Broadside::EcsManager.ecs.describe_tasks(cluster: @target.cluster, tasks: task_arns), '')).aqua,
           "\n",
           Rainbow("Private ips of instances running containers:\n").underline,
           Rainbow(ips.join(' ')).blue,

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -104,11 +104,7 @@ module Broadside
       super do
         ips = EcsManager.get_running_instance_ips(@target.cluster, family)
         task_arns = Broadside::EcsManager.get_task_arns(@target.cluster, family)
-        tasks = if task_arns.nil? || task_arns.empty?
-                  'None'
-                else
-                  Broadside::EcsManager.ecs.describe_tasks(cluster: @target.cluster, tasks: task_arns)
-                end
+        tasks = task_arns.empty? ? 'None' : Broadside::EcsManager.ecs.describe_tasks(cluster: @target.cluster, tasks: task_arns)
 
         info "\n---------------\n",
           Rainbow("Current task definition information:\n").underline,

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -118,7 +118,7 @@ module Broadside
           Rainbow("Private ips of instances running containers:\n").underline,
           Rainbow(ips.join(' ')).blue,
           "\n\n",
-          Rainbow("ssh command:").underline,
+          Rainbow("ssh command:\n").underline,
           Rainbow(gen_ssh_cmd(ips.first)).cyan,
           "\n"
       end

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -109,7 +109,7 @@ module Broadside
 
         info "\n---------------\n",
           Rainbow("Current task definition information:\n").underline,
-          Rainbow(PP.pp(EcsManager.get_latest_task_definition(family), '', WIDTH)).blue,
+          Rainbow(PP.pp(EcsManager.get_latest_task_definition(family), '', WIDTH)).blue.bright,
           "\n",
           Rainbow("Current service information:\n").underline,
           Rainbow(PP.pp(EcsManager.ecs.describe_services(cluster: @target.cluster, services: [family]).to_hash, '', WIDTH)).aliceblue,

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -104,8 +104,8 @@ module Broadside
     def status
       super do
         ips = EcsManager.get_running_instance_ips(@target.cluster, family)
-        task_arns = Broadside::EcsManager.get_task_arns(@target.cluster, family)
-        tasks = task_arns.empty? ? 'None' : Broadside::EcsManager.ecs.describe_tasks(cluster: @target.cluster, tasks: task_arns).to_hash
+        tasks = EcsManager.describe_all_tasks(@target.cluster, family)
+        tasks = tasks ? tasks.to_hash : 'No tasks found'
 
         info "\n---------------\n",
           Rainbow("Current task definition information:\n").underline,

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -104,14 +104,14 @@ module Broadside
       super do
         ips = EcsManager.get_running_instance_ips(@target.cluster, family)
         task_arns = Broadside::EcsManager.get_task_arns(@target.cluster, family)
-        tasks = task_arns.empty? ? 'None' : Broadside::EcsManager.ecs.describe_tasks(cluster: @target.cluster, tasks: task_arns)
+        tasks = task_arns.empty? ? 'None' : Broadside::EcsManager.ecs.describe_tasks(cluster: @target.cluster, tasks: task_arns).to_hash
 
         info "\n---------------\n",
           Rainbow("Current task definition information:\n").underline,
           Rainbow(PP.pp(EcsManager.get_latest_task_definition(family), '')).blue,
           "\n",
           Rainbow("Current service information:\n").underline,
-          Rainbow(PP.pp(EcsManager.ecs.describe_services(cluster: @target.cluster, services: [family]), '')).aliceblue,
+          Rainbow(PP.pp(EcsManager.ecs.describe_services(cluster: @target.cluster, services: [family]).to_hash, '')).aliceblue,
           "\n",
           Rainbow("Task information:\n").underline,
           Rainbow(PP.pp(tasks, '')).aqua,

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -121,7 +121,7 @@ module Broadside
           Rainbow(PP.pp(tasks, '')).aqua,
           "\n\n",
           Rainbow("IPs and SSH commands:\n").underline,
-          Rainbow(ips.map { |ip| "#{ip} #{gen_ssh_cmd(ip)}"}.join("\n")).cyan,
+          Rainbow(ips.map { |ip| "#{ip}: #{gen_ssh_cmd(ip)}"}.join("\n")).cyan,
           "\n"
       end
     end

--- a/lib/broadside/ecs/ecs_manager.rb
+++ b/lib/broadside/ecs/ecs_manager.rb
@@ -44,6 +44,11 @@ module Broadside
         get_task_definition_arns(name).last
       end
 
+      def describe_all_tasks(cluster, family)
+        task_arns = get_task_arns(cluster, family)
+        task_arns.empty? ? nil : ecs.describe_tasks(cluster: cluster, tasks: task_arns)
+      end
+
       def get_running_instance_ips(cluster, family, task_arns = nil)
         task_arns = task_arns ? Array.wrap(task_arns) : get_task_arns(cluster, family)
         raise Error, "No running tasks found for '#{family}' on cluster '#{cluster}'!" if task_arns.empty?


### PR DESCRIPTION
Never use the AWS GUI again - this gives you an insane amount of fancily multicolored output about the tasks, task definitions, service (with event history), and some other stuff.

(I was really, really tired of digging through the ECS Services GUI for the event history)

cc @dtboctor @timchan-lumoslabs @jdoconnor 

the only thing the GUI is useful for now is probably the CPU and memory usage metrics.