### PR TITLE
Better messaging for tasks unable to start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Exceptions will be raised if a target is configured with an invalid hash key
 - Tasks run have a more relevant `started_by` tag
 - Default loglevel changed to INFO
+- [#21](https://github.com/lumoslabs/broadside/issues/21) Print more useful messages when tasks die without exit codes.
 
 # 2.0.0
 #### Breaking Changes

--- a/lib/broadside/deploy.rb
+++ b/lib/broadside/deploy.rb
@@ -4,6 +4,7 @@ module Broadside
 
     attr_reader :command, :tag, :target
     delegate :family, to: :target
+    delegate :cluster, to: :target
 
     def initialize(target_name, options = {})
       @target   = Broadside.config.get_target_by_name!(target_name)

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -201,7 +201,7 @@ module Broadside
           task_arn = EcsManager.run_task(cluster, family, command, options).tasks[0].task_arn
           info "Launched #{command_name} task #{task_arn}, waiting for completion..."
 
-          EcsManager.ecs.wait_until(:tasks_stopped, { cluster: cluster, tasks: [task_arn] }) do |w|
+          EcsManager.ecs.wait_until(:tasks_stopped, cluster: cluster, tasks: [task_arn]) do |w|
             w.max_attempts = nil
             w.delay = Broadside.config.ecs.poll_frequency
             w.before_attempt do |attempt|

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -46,7 +46,7 @@ module Broadside
 
       run_commands(@target.bootstrap_commands, started_by: 'bootstrap')
 
-      if EcsManager.service_exists?(@target.cluster, family)
+      if EcsManager.service_exists?(cluster, family)
         info("Service for #{family} already exists.")
       else
         unless @target.service_config
@@ -54,7 +54,7 @@ module Broadside
         end
 
         info "Service '#{family}' doesn't exist, creating..."
-        EcsManager.create_service(@target.cluster, family, @target.service_config)
+        EcsManager.create_service(cluster, family, @target.service_config)
       end
     end
 
@@ -122,7 +122,7 @@ module Broadside
     end
 
     def check_service!
-      unless EcsManager.service_exists?(@target.cluster, family)
+      unless EcsManager.service_exists?(cluster, family)
         raise Error, "No service for '#{family}'! Please bootstrap or manually configure one."
       end
     end
@@ -134,7 +134,7 @@ module Broadside
 
     def get_running_instance_ip!
       check_service_and_task_definition!
-      EcsManager.get_running_instance_ips!(@target.cluster, family).fetch(@instance)
+      EcsManager.get_running_instance_ips!(cluster, family).fetch(@instance)
     end
 
     # Creates a new task revision using current directory's env vars, provided tag, and @target.task_definition_config
@@ -164,7 +164,7 @@ module Broadside
       debug "Updating #{family} with scale=#{@scale} using task_definition #{task_definition_arn}..."
 
       update_service_response = EcsManager.ecs.update_service({
-        cluster: @target.cluster,
+        cluster: cluster,
         desired_count: @scale,
         service: family,
         task_definition: task_definition_arn
@@ -174,7 +174,7 @@ module Broadside
         raise Error, "Failed to update service:\n#{update_service_response.pretty_inspect}"
       end
 
-      EcsManager.ecs.wait_until(:services_stable, cluster: @target.cluster, services: [family]) do |w|
+      EcsManager.ecs.wait_until(:services_stable, cluster: cluster, services: [family]) do |w|
         timeout = Broadside.config.timeout
         w.delay = Broadside.config.ecs.poll_frequency
         w.max_attempts = timeout ? timeout / w.delay : Float::INFINITY
@@ -198,10 +198,10 @@ module Broadside
       begin
         commands.each do |command|
           command_name = "'#{command.join(' ')}'"
-          task_arn = EcsManager.run_task(@target.cluster, family, command, options).tasks[0].task_arn
+          task_arn = EcsManager.run_task(cluster, family, command, options).tasks[0].task_arn
           info "Launched #{command_name} task #{task_arn}, waiting for completion..."
 
-          EcsManager.ecs.wait_until(:tasks_stopped, { cluster: @target.cluster, tasks: [task_arn] }) do |w|
+          EcsManager.ecs.wait_until(:tasks_stopped, { cluster: cluster, tasks: [task_arn] }) do |w|
             w.max_attempts = nil
             w.delay = Broadside.config.ecs.poll_frequency
             w.before_attempt do |attempt|
@@ -209,11 +209,11 @@ module Broadside
             end
           end
 
+          exit_status = EcsManager.get_task_exit_status(cluster, task_arn, family)
+          raise Error, "#{command_name} task #{task_arn} failed to start:\n'#{exit_status[:reason]}'" if exit_status[:exit_code].nil?
+          raise Error, "#{command_name} task #{task_arn} failed with non-zero exit code: #{exit_status[:exit_code]}!" unless exit_status[:exit_code].zero?
+
           info "#{command_name} task container logs:\n#{get_container_logs(task_arn)}"
-
-          exit_code = EcsManager.get_task_exit_code(@target.cluster, task_arn, family)
-          raise Error, "#{command_name} task #{task_arn} exit code: #{exit_code}!" unless exit_code.zero?
-
           info "#{command_name} task #{task_arn} complete"
         end
       ensure
@@ -222,7 +222,7 @@ module Broadside
     end
 
     def get_container_logs(task_arn)
-      ip = EcsManager.get_running_instance_ips!(@target.cluster, family, task_arn).first
+      ip = EcsManager.get_running_instance_ips!(cluster, family, task_arn).first
       debug "Found IP of container instance: #{ip}"
 
       find_container_id_cmd = "#{Broadside.config.ssh_cmd(ip)} \"docker ps -aqf 'label=com.amazonaws.ecs.task-arn=#{task_arn}'\""

--- a/lib/broadside/ecs/ecs_manager.rb
+++ b/lib/broadside/ecs/ecs_manager.rb
@@ -79,10 +79,14 @@ module Broadside
         all_results(:list_task_definitions, :task_definition_arns, { family_prefix: family })
       end
 
-      def get_task_exit_code(cluster, task_arn, name)
+      def get_task_exit_status(cluster, task_arn, name)
         task = ecs.describe_tasks(cluster: cluster, tasks: [task_arn]).tasks.first
         container = task.containers.select { |c| c.name == name }.first
-        container.exit_code
+
+        {
+          exit_code: container.exit_code,
+          reason: container.reason
+        }
       end
 
       def list_task_definition_families
@@ -94,7 +98,7 @@ module Broadside
       end
 
       def run_task(cluster, name, command, options = {})
-        fail ArgumentError, "#{command} must be an array" unless command.is_a?(Array)
+        raise ArgumentError, "#{command} must be an array" unless command.is_a?(Array)
 
         response = ecs.run_task(
           cluster: cluster,

--- a/spec/broadside/ecs/ecs_deploy_spec.rb
+++ b/spec/broadside/ecs/ecs_deploy_spec.rb
@@ -176,25 +176,54 @@ describe Broadside::EcsDeploy do
     end
   end
 
-  describe '#run' do
-    let(:local_deploy_config) { { command: %w(run some command) } }
+  describe '#run_commands' do
+    let(:commands) { [%w(run some command)] }
 
     it 'fails without a task definition' do
-      expect { deploy.run }.to raise_error(/No task definition for /)
+      expect { deploy.send(:run_commands, commands) }.to raise_error(Broadside::Error, /No task definition for/)
     end
 
     context 'with a task_definition' do
       include_context 'with a task_definition'
 
-      before do
+      let(:exit_code) { 0 }
+      let(:reason) { nil }
+      let(:task_exit_status) do
+        {
+          exit_code: exit_code,
+          reason: reason
+        }
+      end
+
+      before(:each) do
         ecs_stub.stub_responses(:run_task, tasks: [task_arn: 'task_arn'])
+        ecs_stub.stub_responses(:wait_until, true)
+        allow(Broadside::EcsManager).to receive(:get_task_exit_status).and_return(task_exit_status)
       end
 
       it 'runs' do
         expect(ecs_stub).to receive(:wait_until)
         expect(deploy).to receive(:get_container_logs)
-        expect(Broadside::EcsManager).to receive(:get_task_exit_code).and_return(0)
-        expect { deploy.run }.to_not raise_error
+        expect { deploy.send(:run_commands, commands) }.to_not raise_error
+      end
+
+      context 'tries to start a task that does not produce an exit code' do
+        let(:exit_code) { nil }
+        let(:reason) { 'CannotPullContainerError: Tag BLARGH not found in repository lumoslabs/my_project' }
+
+        it 'raises an error displaying the failure reason' do
+          expect(ecs_stub).to receive(:wait_until)
+          expect { deploy.send(:run_commands, commands) }.to raise_error(Broadside::Error, /#{reason}/)
+        end
+      end
+
+      context 'starts a task that produces a non-zero exit code' do
+        let(:exit_code) { 9000 }
+
+        it 'raises an error and displays the exit code' do
+          expect(ecs_stub).to receive(:wait_until)
+          expect { deploy.send(:run_commands, commands) }.to raise_error(Broadside::Error, /#{exit_code}/)
+        end
       end
     end
   end


### PR DESCRIPTION
addresses https://github.com/lumoslabs/broadside/issues/21

If a task is launched and mysteriously dies without an exit code, then grab whatever message AWS has about the failure. This covers the whole tag missing issue that would result in deploys mysteriously dying at the first predeploy command.