### PR TITLE
Add BROADSIDE_SYSTEM_CONFIG_FILE environment variable option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [#11](https://github.com/lumoslabs/broadside/issues/11): Add option for ssh proxy user and proxy keyfile
 - [#2](https://github.com/lumoslabs/broadside/issues/2): Add flag for changing loglevel, and add `--debug` switch that enables GLI debug output
 - Failed deploys will rollback the service to the last successfully running scale
+- Allow setting an environment variable `BROADSIDE_SYSTEM_CONFIG_FILE` to be used instead of `~/.broadside/config.rb`
 
 #### General Improvements
 - Only load `env_files` for the selected target (rather than preloading from unrelated targets)

--- a/lib/broadside.rb
+++ b/lib/broadside.rb
@@ -17,7 +17,7 @@ require 'broadside/version'
 module Broadside
   extend LoggingUtils
 
-  USER_CONFIG_FILE = (ENV['BROADSIDE_SYSTEM_CONFIG_FILE'] || "#{Dir.home}/.broadside/config.rb").freeze
+  USER_CONFIG_FILE = (ENV['BROADSIDE_SYSTEM_CONFIG_FILE'] || File.join(Dir.home, '.broadside', 'config.rb').freeze
 
   def self.configure
     yield config

--- a/lib/broadside.rb
+++ b/lib/broadside.rb
@@ -17,7 +17,7 @@ require 'broadside/version'
 module Broadside
   extend LoggingUtils
 
-  USER_CONFIG_FILE = "#{Dir.home}/.broadside/config.rb"
+  USER_CONFIG_FILE = (ENV['BROADSIDE_SYSTEM_CONFIG_FILE'] || "#{Dir.home}/.broadside/config.rb").freeze
 
   def self.configure
     yield config

--- a/lib/broadside/command.rb
+++ b/lib/broadside/command.rb
@@ -6,6 +6,8 @@ module Broadside
   module Command
     extend LoggingUtils
 
+    DEFAULT_TAIL_LINES = 10
+
     class << self
       def targets
         table_header = nil
@@ -87,7 +89,7 @@ module Broadside
       end
 
       def logtail(options)
-        lines = options[:lines] || 10
+        lines = options[:lines] || DEFAULT_TAIL_LINES
         target = Broadside.config.get_target_by_name!(options[:target])
         ip = get_running_instance_ip!(target, *options[:instance])
         info "Tailing logs for running container at #{ip}..."

--- a/lib/broadside/configuration/invalid_configuration.rb
+++ b/lib/broadside/configuration/invalid_configuration.rb
@@ -5,9 +5,5 @@ module Broadside
     def method_missing(m, *args, &block)
       warn "Unknown configuration '#{m}' provided, ignoring."
     end
-
-    def respond_to_missing?(method, include_private = false)
-      super
-    end
   end
 end

--- a/lib/broadside/gli/commands.rb
+++ b/lib/broadside/gli/commands.rb
@@ -68,7 +68,7 @@ end
 desc 'Tail the logs inside a running container.'
 command :logtail do |logtail|
   logtail.desc 'Number of lines to tail'
-  logtail.default_value 10
+  logtail.default_value Broadside::Command::DEFAULT_TAIL_LINES
   logtail.arg_name 'TAIL_LINES'
   logtail.flag [:l, :lines], type: Fixnum
 

--- a/lib/broadside/logging_utils.rb
+++ b/lib/broadside/logging_utils.rb
@@ -2,7 +2,7 @@ module Broadside
   module LoggingUtils
     %w(debug info warn error fatal).each do |log_level|
       define_method(log_level) do |*args|
-        Broadside.config.logger.send(log_level.to_sym, args.join(' '))
+        Broadside.config.logger.public_send(log_level.to_sym, args.join(' '))
       end
     end
   end

--- a/lib/broadside/logging_utils.rb
+++ b/lib/broadside/logging_utils.rb
@@ -1,19 +1,9 @@
 module Broadside
   module LoggingUtils
-    def debug(*args)
-      Broadside.config.logger.debug(args.join(' '))
-    end
-
-    def info(*args)
-      Broadside.config.logger.info(args.join(' '))
-    end
-
-    def warn(*args)
-      Broadside.config.logger.warn(args.join(' '))
-    end
-
-    def error(*args)
-      Broadside.config.logger.error(args.join(' '))
+    %w(debug info warn error fatal).each do |log_level|
+      define_method(log_level) do |*args|
+        Broadside.config.logger.send(log_level.to_sym, args.join(' '))
+      end
     end
   end
 end


### PR DESCRIPTION
I feel like this might aid the switchover to 3.0... can temporarily point yourself at a new system config.  Might be overkill though.

i also refactored `DEFAULT_TAIL_LINES` and got rid of `respond_to_missing`; see note on that latter