### PR TITLE
Allow ecs config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Configuration changes:
   - `config.git_repo=` and `config.type=` were removed.
   - `config.base` and `config.deploy` are no longer backwards compatible - any options configured at `config.base.something` or `config.deploy.something` must now be configured at `config.something`
-  - `config.ecs.cluster` and `config.ecs.poll_frequency` are now configured at `config.aws.ecs_default_cluster` and `config.aws.ecs_poll_frequency`
+  - `config.ecs.cluster` and is now configured at `config.ecs.default_cluster`
   - `config.docker_image` is now `config.default_docker_image`
   - `instance` can no longer be configured on a per `Target` basis
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Applications using broadside employ a configuration file that looks something li
 Broadside.configure do |config|
   config.application = 'hello_world'
   config.default_docker_image = 'lumoslabs/hello_world'
-  config.aws.ecs_default_cluster = 'production-cluster'
+  config.ecs.default_cluster = 'production-cluster'
   config.aws.region = 'us-east-1'                  # 'us-east-1 is the default
   config.targets = {
     production_web: {

--- a/lib/broadside/configuration/aws_configuration.rb
+++ b/lib/broadside/configuration/aws_configuration.rb
@@ -4,21 +4,21 @@ module Broadside
     include InvalidConfiguration
 
     validates :region, presence: true, strict: ConfigurationError
-    validates :ecs_poll_frequency, numericality: { only_integer: true, strict: ConfigurationError }
+    validates :poll_frequency, numericality: { only_integer: true, strict: ConfigurationError }
     validates_each(:credentials) do |_, _, val|
       raise ConfigurationError, 'credentials is not of type Aws::Credentials' unless val.is_a?(Aws::Credentials)
     end
 
     attr_accessor(
       :credentials,
-      :ecs_default_cluster,
-      :ecs_poll_frequency,
+      :default_cluster,
+      :poll_frequency,
       :region
     )
 
     def initialize
       @credentials = Aws::SharedCredentials.new.credentials
-      @ecs_poll_frequency = 2
+      @poll_frequency = 2
       @region = 'us-east-1'
     end
   end

--- a/lib/broadside/configuration/configuration.rb
+++ b/lib/broadside/configuration/configuration.rb
@@ -3,7 +3,6 @@ require 'logger'
 module Broadside
   class Configuration
     include ActiveModel::Model
-    include LoggingUtils
     include InvalidConfiguration
 
     attr_reader(

--- a/lib/broadside/configuration/configuration.rb
+++ b/lib/broadside/configuration/configuration.rb
@@ -40,6 +40,10 @@ module Broadside
       @timeout = 600
     end
 
+    def ecs
+      @aws
+    end
+
     # Transform deploy target configs to Target objects
     def targets=(targets_hash)
       raise ConfigurationError, ':targets must be a hash' unless targets_hash.is_a?(Hash)

--- a/lib/broadside/configuration/invalid_configuration.rb
+++ b/lib/broadside/configuration/invalid_configuration.rb
@@ -2,8 +2,8 @@ module Broadside
   module InvalidConfiguration
     extend LoggingUtils
 
-    def method_missing(m, *args, &block)
-      warn "Unknown configuration '#{m}' provided, ignoring."
+    def method_missing(m, _, &block)
+      warn "Unknown configuration '#{m}' provided, ignoring..."
     end
   end
 end

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -83,7 +83,7 @@ module Broadside
 
           EcsManager.ecs.wait_until(:tasks_stopped, cluster: cluster, tasks: [task_arn]) do |w|
             w.max_attempts = nil
-            w.delay = Broadside.config.aws.ecs_poll_frequency
+            w.delay = Broadside.config.aws.poll_frequency
             w.before_attempt do |attempt|
               info "Attempt #{attempt}: waiting for #{command_name} to complete..."
             end
@@ -160,7 +160,7 @@ module Broadside
 
       EcsManager.ecs.wait_until(:services_stable, cluster: cluster, services: [family]) do |w|
         timeout = Broadside.config.timeout
-        w.delay = Broadside.config.aws.ecs_poll_frequency
+        w.delay = Broadside.config.aws.poll_frequency
         w.max_attempts = timeout ? timeout / w.delay : nil
         seen_event_id = nil
 

--- a/lib/broadside/target.rb
+++ b/lib/broadside/target.rb
@@ -49,7 +49,7 @@ module Broadside
 
       config = options.deep_dup
       @bootstrap_commands     = config.delete(:bootstrap_commands)
-      @cluster                = config.delete(:cluster) || Broadside.config.aws.ecs_default_cluster
+      @cluster                = config.delete(:cluster) || Broadside.config.ecs.default_cluster
       @command                = config.delete(:command)
       @docker_image           = config.delete(:docker_image) || Broadside.config.default_docker_image
       @predeploy_commands     = config.delete(:predeploy_commands)

--- a/spec/broadside/configuration_spec.rb
+++ b/spec/broadside/configuration_spec.rb
@@ -13,7 +13,7 @@ describe Broadside::Configuration do
 
   it 'should raise an error when ecs is misconfigured' do
     expect { Broadside.configure { |config| config.aws.region = nil } }.to raise_error(ArgumentError)
-    expect { Broadside.configure { |config| config.aws.ecs_poll_frequency = 'poll' } }.to raise_error(ArgumentError)
+    expect { Broadside.configure { |config| config.ecs.poll_frequency = 'poll' } }.to raise_error(ArgumentError)
     expect { Broadside.configure { |config| config.aws.credentials = 'password' } }.to raise_error(ArgumentError)
   end
 

--- a/spec/fixtures/broadside_app_example.conf.rb
+++ b/spec/fixtures/broadside_app_example.conf.rb
@@ -1,6 +1,6 @@
 Broadside.configure do |c|
   c.aws.credentials = Aws::Credentials.new('access', 'secret')
-  c.aws.ecs_default_cluster = cluster
+  c.ecs.default_cluster = cluster
   c.application = test_app
   c.default_docker_image = 'rails'
   c.logger.level = Logger::ERROR


### PR DESCRIPTION
For some reason `config.aws.ecs_default_cluster` wasn't sitting well with me, so this is a compromise - `config.ecs` still works, but it just is the same `AwsConfig` object.  thoughts?

`config.ecs.default_cluster` just makes more sense.