### PR TITLE
Use strict configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Broadside.configure do |config|
       command: ['bundle', 'exec', 'puma'],
       env_file: '.env.staging',
       tag: 'latest',                                # Set a default tag for this target
-      cluster: 'staging-cluster',                   # Overrides config.ecs.cluster
-      docker_image: 'lumoslabs/staging_hello_world' # Overrides config.docker_image
+      cluster: 'staging-cluster',                   # Overrides config.aws.ecs_default_cluster
+      docker_image: 'lumoslabs/staging_hello_world' # Overrides config.default_docker_image
     },
     json_stream: {
       scale: 1,

--- a/lib/broadside/configuration/configuration.rb
+++ b/lib/broadside/configuration/configuration.rb
@@ -3,7 +3,6 @@ require 'logger'
 module Broadside
   class Configuration
     include ActiveModel::Model
-    include LoggingUtils
     include InvalidConfiguration
 
     attr_reader(

--- a/lib/broadside/configuration/invalid_configuration.rb
+++ b/lib/broadside/configuration/invalid_configuration.rb
@@ -1,9 +1,7 @@
 module Broadside
   module InvalidConfiguration
-    extend LoggingUtils
-
-    def method_missing(m, *args, &block)
-      warn "Unknown configuration '#{m}' provided, ignoring."
+    def method_missing(m, _, &block)
+      raise ConfigurationError, "Unknown configuration '#{m}' provided!"
     end
   end
 end

--- a/lib/broadside/configuration/invalid_configuration.rb
+++ b/lib/broadside/configuration/invalid_configuration.rb
@@ -1,7 +1,7 @@
 module Broadside
   module InvalidConfiguration
     def method_missing(m, *args, &block)
-      message = "Unknown '#{m}' provided for #{self.is_a?(AwsConfiguration) ? 'configuration.aws' : 'configuration'}!"
+      message = "Unknown '#{m}' provided for #{is_a?(AwsConfiguration) ? 'configuration.aws' : 'configuration'}!"
       raise ArgumentError, message
     end
   end

--- a/lib/broadside/configuration/invalid_configuration.rb
+++ b/lib/broadside/configuration/invalid_configuration.rb
@@ -1,7 +1,8 @@
 module Broadside
   module InvalidConfiguration
     def method_missing(m, *args, &block)
-      raise ArgumentError, "Unknown configuration '#{m}' provided for #{self.class}!"
+      message = "Unknown '#{m}' provided for #{self.is_a?(AwsConfiguration) ? 'configuration.aws' : 'configuration'}!"
+      raise ArgumentError, message
     end
   end
 end

--- a/lib/broadside/configuration/invalid_configuration.rb
+++ b/lib/broadside/configuration/invalid_configuration.rb
@@ -1,7 +1,7 @@
 module Broadside
   module InvalidConfiguration
-    def method_missing(m, _, &block)
-      raise ConfigurationError, "Unknown configuration '#{m}' provided!"
+    def method_missing(m, *args, &block)
+      raise ArgumentError, "Unknown configuration '#{m}' provided for #{self.class}!"
     end
   end
 end

--- a/lib/broadside/target.rb
+++ b/lib/broadside/target.rb
@@ -66,7 +66,7 @@ module Broadside
       end
 
       raise ConfigurationError, errors.full_messages unless valid?
-      warn "Target #{@name} was configured with invalid/unused options: #{config}" unless config.empty?
+      raise ConfigurationError, "Target #{@name} was configured with invalid options: #{config}" unless config.empty?
     end
 
     def ecs_env_vars

--- a/spec/broadside/configuration_spec.rb
+++ b/spec/broadside/configuration_spec.rb
@@ -17,6 +17,11 @@ describe Broadside::Configuration do
     expect { Broadside.configure { |config| config.aws.credentials = 'password' } }.to raise_error(ArgumentError)
   end
 
+  it 'should raise a relevant method missing error when misconfigured' do
+    expect { Broadside.configure { |config| config.aws.bad = 5 } }.to raise_error(ArgumentError, "Unknown 'bad=' provided for configuration.aws!")
+    expect { Broadside.configure { |config| config.bad = 5 } }.to raise_error(ArgumentError, "Unknown 'bad=' provided for configuration!")
+  end
+
   describe '#ssh_cmd' do
     let(:ip) { '123.123.123.123' }
     let(:ssh_config) { {} }


### PR DESCRIPTION
I dislike the "warn on bad config" approach because I feel like often times when you have a misspelling or something in the configuration file, it is actively A Real Problem that could affect your deployment and the deploy should not be allowed to proceed.

I do however agree that more helpful error messaging is super useful, so I left the `InvalidConfig` module in place - just changed it to raise an exception.