### PR TITLE
Enable setting up a new ELB during bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Broadside.configure do |config|
       scale: 1,
       command: ['java', '-cp', '*:.', 'path.to.MyClass'],
       # This target has a task_definition and service config which you use to bootstrap a new AWS Service
-      # with an elastic load balancer.  (The load balancer is optional.)
+      # along with an ELB configured with :load_balancer_config.  The load balancer is optional.
       load_balancer_config: { subnets: [ 'subnet-xyz', 'subnet-abc'] },
       service_config: { deployment_configuration: { minimum_healthy_percent: 0.5 } },
       task_definition_config: { container_definitions: [ { cpu: 1, memory: 2000, } ] }

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Broadside.configure do |config|
       command: ['java', '-cp', '*:.', 'path.to.MyClass'],
       # This target has a task_definition and service config which you use to bootstrap a new AWS Service
       # along with an ELB configured with :load_balancer_config.  The load balancer is optional.
-      load_balancer_config: { subnets: [ 'subnet-xyz', 'subnet-abc'] },
+      load_balancer_config: { subnets: ['subnet-xyz', 'subnet-abc'] },
       service_config: { deployment_configuration: { minimum_healthy_percent: 0.5 } },
       task_definition_config: { container_definitions: [ { cpu: 1, memory: 2000, } ] }
     }

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Broadside.configure do |config|
       scale: 1,
       command: ['java', '-cp', '*:.', 'path.to.MyClass'],
       # This target has a task_definition and service config which you use to bootstrap a new AWS Service
+      # with an elastic load balancer.  (The load balancer is optional.)
+      load_balancer_config: { subnets: [ 'subnet-xyz', 'subnet-abc'] },
       service_config: { deployment_configuration: { minimum_healthy_percent: 0.5 } },
       task_definition_config: { container_definitions: [ { cpu: 1, memory: 2000, } ] }
     }

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -56,6 +56,7 @@ module Broadside
         info "Service '#{family}' doesn't exist, creating..."
 
         if @target.load_balancer_config
+          # We cautiously default to an internal ELB; the AWS default is `internet-facing`
           load_balancer_config = { scheme: 'internal', name: family }.merge(@target.load_balancer_config)
           EcsManager.create_load_balancer(load_balancer_config)
           EcsManager.create_service(cluster, family, @target.service_config.merge(load_balancers: [load_balancer_name: family]))

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -56,7 +56,8 @@ module Broadside
         info "Service '#{family}' doesn't exist, creating..."
 
         if @target.load_balancer_config
-          EcsManager.create_load_balancer(@target.load_balancer_config.merge(name: family))
+          load_balancer_config = { scheme: 'internal', name: family }.merge(@target.load_balancer_config)
+          EcsManager.create_load_balancer(load_balancer_config)
           EcsManager.create_service(cluster, family, @target.service_config.merge(load_balancers: [load_balancer_name: family]))
         else
           EcsManager.create_service(cluster, family, @target.service_config)

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -52,7 +52,7 @@ module Broadside
             # Verify ELB definition matches
           else
             raise ConfigurationError, "No ELB #{elb_name}/no :load_balancer_config" unless @target.load_balancer_config
-            EcsManager.create_load_balancer(@target.load_balancer_config.merge(load_balancer_name: elb_name), family)
+            EcsManager.create_load_balancer(@target.load_balancer_config.merge(name: elb_name), family)
           end
         end
 

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -52,7 +52,7 @@ module Broadside
             # Verify ELB definition matches
           else
             raise ConfigurationError, "No ELB #{elb_name}/no :load_balancer_config" unless @target.load_balancer_config
-            EcsManager.create_load_balancer(@target.load_balancer_config.merge(load_balancer_name: elb_name))
+            EcsManager.create_load_balancer(@target.load_balancer_config.merge(load_balancer_name: elb_name), family)
           end
         end
 

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -44,6 +44,18 @@ module Broadside
         info("Service for #{family} already exists.")
       else
         raise ConfigurationError, "No :service_config for #{family}" unless @target.service_config
+
+        if @target.service_config[:load_balancers]
+          elb_name = @target.service_config[:load_balancers].first[:load_balancer_name]
+
+          if (elb_arn = EcsManager.get_load_balancer_arn_by_name(elb_name))
+            # Verify ELB definition matches
+          else
+            raise ConfigurationError, "No ELB #{elb_name}/no :load_balancer_config" unless @target.load_balancer_config
+            EcsManager.create_load_balancer(@target.load_balancer_config)
+          end
+        end
+
         info "Service '#{family}' doesn't exist, creating..."
         EcsManager.create_service(cluster, family, @target.service_config)
       end

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -60,6 +60,7 @@ module Broadside
 
           # We cautiously default to an internal ELB; the AWS default is `internet-facing`
           EcsManager.create_load_balancer({ scheme: 'internal', name: family }.merge(@target.load_balancer_config))
+
           EcsManager.create_service(
             cluster,
             family,

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -56,12 +56,14 @@ module Broadside
         info "Service '#{family}' doesn't exist, creating..."
 
         if @target.load_balancer_config
+          container_port = EcsManager.get_latest_task_definition(family)[:container_definitions].first[:port_mappings].first[:container_port]
+
           # We cautiously default to an internal ELB; the AWS default is `internet-facing`
           EcsManager.create_load_balancer({ scheme: 'internal', name: family }.merge(@target.load_balancer_config))
           EcsManager.create_service(
             cluster,
             family,
-            @target.service_config.merge(load_balancers: [load_balancer_name: family])
+            @target.service_config.merge(load_balancers: [container_name: family, container_port: container_port, load_balancer_name: family])
           )
         else
           EcsManager.create_service(cluster, family, @target.service_config)

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -63,7 +63,9 @@ module Broadside
           EcsManager.create_service(
             cluster,
             family,
-            @target.service_config.merge(load_balancers: [container_name: family, container_port: container_port, load_balancer_name: family])
+            @target.service_config.merge(
+              load_balancers: [container_name: family, container_port: container_port, load_balancer_name: family]
+            )
           )
         else
           EcsManager.create_service(cluster, family, @target.service_config)

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -57,9 +57,12 @@ module Broadside
 
         if @target.load_balancer_config
           # We cautiously default to an internal ELB; the AWS default is `internet-facing`
-          load_balancer_config = { scheme: 'internal', name: family }.merge(@target.load_balancer_config)
-          EcsManager.create_load_balancer(load_balancer_config)
-          EcsManager.create_service(cluster, family, @target.service_config.merge(load_balancers: [load_balancer_name: family]))
+          EcsManager.create_load_balancer({ scheme: 'internal', name: family }.merge(@target.load_balancer_config))
+          EcsManager.create_service(
+            cluster,
+            family,
+            @target.service_config.merge(load_balancers: [load_balancer_name: family])
+          )
         else
           EcsManager.create_service(cluster, family, @target.service_config)
         end

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -52,7 +52,7 @@ module Broadside
             # Verify ELB definition matches
           else
             raise ConfigurationError, "No ELB #{elb_name}/no :load_balancer_config" unless @target.load_balancer_config
-            EcsManager.create_load_balancer(@target.load_balancer_config)
+            EcsManager.create_load_balancer(@target.load_balancer_config.merge(load_balancer_name: elb_name))
           end
         end
 

--- a/lib/broadside/ecs/ecs_manager.rb
+++ b/lib/broadside/ecs/ecs_manager.rb
@@ -184,8 +184,8 @@ module Broadside
 
       def elb_client
         @elb_client ||= Aws::ElasticLoadBalancingV2::Client.new(
-          region: region_name,
-          credentials: credentials
+          region: Broadside.config.aws.region,
+          credentials: Broadside.config.aws.credentials
         )
       end
     end

--- a/lib/broadside/ecs/ecs_manager.rb
+++ b/lib/broadside/ecs/ecs_manager.rb
@@ -149,7 +149,7 @@ module Broadside
         EcsManager.ecs.describe_services(cluster: target.cluster, services: [target.family]).services.first[:desired_count]
       end
 
-      # Returns the load balancer response hash
+      # Returns the load balancer description hash
       def create_load_balancer(load_balancer_config)
         # Docs say tags are required but sandbox accepts ELB definitions without :tags
         tags = [{ key: 'family', value: load_balancer_config[:name] }]

--- a/lib/broadside/ecs/ecs_manager.rb
+++ b/lib/broadside/ecs/ecs_manager.rb
@@ -157,7 +157,7 @@ module Broadside
       end
 
       def get_load_balancer_arn_by_name(name)
-        load_balancers = elb_client.describe_load_balancers().load_balancers
+        load_balancers = elb_client.describe_load_balancers.load_balancers
         load_balancers.detect { |lb| lb.load_balancer_name == name }.try(:[], :load_balancer_arn)
       end
 

--- a/lib/broadside/ecs/ecs_manager.rb
+++ b/lib/broadside/ecs/ecs_manager.rb
@@ -149,6 +149,16 @@ module Broadside
         EcsManager.ecs.describe_services(cluster: target.cluster, services: [target.family]).services.first[:desired_count]
       end
 
+      # Returns the load balancer response hash
+      def create_load_balancer(load_balancer_config)
+        elb_client.create_load_balancer(load_balancer_config).load_balancers.first.to_hash
+      end
+
+      def get_load_balancer_arn_by_name(name)
+        load_balancers = elb_client.describe_load_balancers().load_balancers
+        load_balancers.detect { |lb| lb.load_balancer_name == name }.try(:[], :load_balancer_arn)
+      end
+
       private
 
       def all_results(method, key, args = {})
@@ -167,6 +177,13 @@ module Broadside
         @ec2_client ||= Aws::EC2::Client.new(
           region: Broadside.config.aws.region,
           credentials: Broadside.config.aws.credentials
+        )
+      end
+
+      def elb_client
+        @elb_client ||= Aws::ElasticLoadBalancingV2::Client.new(
+          region: region_name,
+          credentials: credentials
         )
       end
     end

--- a/lib/broadside/ecs/ecs_manager.rb
+++ b/lib/broadside/ecs/ecs_manager.rb
@@ -150,9 +150,9 @@ module Broadside
       end
 
       # Returns the load balancer response hash
-      def create_load_balancer(load_balancer_config, family = nil)
-        # Docs say tags are required but sandbox says otherwise
-        tags = [{ key: 'family', value: family }] if family
+      def create_load_balancer(load_balancer_config)
+        # Docs say tags are required but sandbox accepts ELB definitions without :tags
+        tags = [{ key: 'family', value: load_balancer_config[:name] }]
         elb_client.create_load_balancer(load_balancer_config.merge(tags: tags)).load_balancers.first.to_h
       end
 

--- a/lib/broadside/ecs/ecs_manager.rb
+++ b/lib/broadside/ecs/ecs_manager.rb
@@ -150,8 +150,10 @@ module Broadside
       end
 
       # Returns the load balancer response hash
-      def create_load_balancer(load_balancer_config)
-        elb_client.create_load_balancer(load_balancer_config).load_balancers.first.to_hash
+      def create_load_balancer(load_balancer_config, family = nil)
+        # Docs say tags are required but sandbox says otherwise
+        tags = [{ key: 'family', value: family }] if family
+        elb_client.create_load_balancer(load_balancer_config.merge(tags: tags)).load_balancers.first.to_h
       end
 
       def get_load_balancer_arn_by_name(name)

--- a/lib/broadside/target.rb
+++ b/lib/broadside/target.rb
@@ -29,14 +29,18 @@ module Broadside
 
     validates_each(:service_config, allow_nil: true) do |record, attr, val|
       record.errors.add(attr, 'is not a hash') unless val.is_a?(Hash)
-      if (elbs = val[:load_balancers].try(:first))
-        record.errors.add(:load_balancer_config) unless elbs[:load_balancer_name]
+      if (elb = val[:load_balancers].try(:first))
+        record.errors.add(:load_balancer_config) unless elb[:load_balancer_name]
       end
     end
 
     validates_each(:load_balancer_config, allow_nil: true) do |record, attr, val|
       record.errors.add(attr, 'is not a hash') unless val.is_a?(Hash)
       record.errors.add(attr, ':load_balancer_name is specified in :service_config') if val[:load_balancer_name]
+      # TODO: validate tag?
+      [:subnets].each do |elb_property|
+        record.errors.add(attr, "#{elb_property} is required in :load_balancer_config") unless val[elb_property]
+      end
     end
 
     validates_each(:task_definition_config, allow_nil: true) do |record, attr, val|

--- a/lib/broadside/target.rb
+++ b/lib/broadside/target.rb
@@ -11,6 +11,7 @@ module Broadside
       :cluster,
       :command,
       :docker_image,
+      :load_balancer_config,
       :name,
       :predeploy_commands,
       :scale,
@@ -26,7 +27,7 @@ module Broadside
       record.errors.add(attr, 'is not array of arrays') unless val.is_a?(Array) && val.all? { |v| v.is_a?(Array) }
     end
 
-    validates_each(:service_config, allow_nil: true) do |record, attr, val|
+    validates_each(:load_balancer_config, :service_config, allow_nil: true) do |record, attr, val|
       record.errors.add(attr, 'is not a hash') unless val.is_a?(Hash)
     end
 
@@ -52,6 +53,7 @@ module Broadside
       @cluster                = config.delete(:cluster) || Broadside.config.aws.ecs_default_cluster
       @command                = config.delete(:command)
       @docker_image           = config.delete(:docker_image) || Broadside.config.default_docker_image
+      @load_balancer_config   = config.delete(:load_balancer_config)
       @predeploy_commands     = config.delete(:predeploy_commands)
       @scale                  = config.delete(:scale)
       @service_config         = config.delete(:service_config)

--- a/lib/broadside/target.rb
+++ b/lib/broadside/target.rb
@@ -33,11 +33,8 @@ module Broadside
 
     validates_each(:load_balancer_config, allow_nil: true) do |record, attr, val|
       record.errors.add(attr, 'is not a hash') unless val.is_a?(Hash)
-      record.errors.add(attr, ':load_balancer_name is specified in :service_config') if val[:load_balancer_name]
-      # TODO: validate tag?
-      [:subnets].each do |elb_property|
-        record.errors.add(attr, "#{elb_property} is required in :load_balancer_config") unless val[elb_property]
-      end
+      record.errors.add(attr, ':load_balancer_name is set automatically') if val[:load_balancer_name]
+      record.errors.add(attr, ":subnets is required") unless val[:subnets] && val[:subnets].is_a?(Array)
     end
 
     validates_each(:task_definition_config, allow_nil: true) do |record, attr, val|

--- a/lib/broadside/target.rb
+++ b/lib/broadside/target.rb
@@ -29,9 +29,6 @@ module Broadside
 
     validates_each(:service_config, allow_nil: true) do |record, attr, val|
       record.errors.add(attr, 'is not a hash') unless val.is_a?(Hash)
-      if (elb = val[:load_balancers].try(:first))
-        record.errors.add(:load_balancer_config) unless elb[:load_balancer_name]
-      end
     end
 
     validates_each(:load_balancer_config, allow_nil: true) do |record, attr, val|

--- a/lib/broadside/target.rb
+++ b/lib/broadside/target.rb
@@ -34,7 +34,7 @@ module Broadside
     validates_each(:load_balancer_config, allow_nil: true) do |record, attr, val|
       record.errors.add(attr, 'is not a hash') unless val.is_a?(Hash)
       record.errors.add(attr, ':load_balancer_name is set automatically') if val[:load_balancer_name]
-      record.errors.add(attr, ":subnets is required") unless val[:subnets] && val[:subnets].is_a?(Array)
+      record.errors.add(attr, ':subnets is required') unless val[:subnets] && val[:subnets].is_a?(Array)
     end
 
     validates_each(:task_definition_config, allow_nil: true) do |record, attr, val|

--- a/lib/broadside/target.rb
+++ b/lib/broadside/target.rb
@@ -27,8 +27,16 @@ module Broadside
       record.errors.add(attr, 'is not array of arrays') unless val.is_a?(Array) && val.all? { |v| v.is_a?(Array) }
     end
 
-    validates_each(:load_balancer_config, :service_config, allow_nil: true) do |record, attr, val|
+    validates_each(:service_config, allow_nil: true) do |record, attr, val|
       record.errors.add(attr, 'is not a hash') unless val.is_a?(Hash)
+      if (elbs = val[:load_balancers].try(:first))
+        record.errors.add(:load_balancer_config) unless elbs[:load_balancer_name]
+      end
+    end
+
+    validates_each(:load_balancer_config, allow_nil: true) do |record, attr, val|
+      record.errors.add(attr, 'is not a hash') unless val.is_a?(Hash)
+      record.errors.add(attr, ':load_balancer_name is specified in :service_config') if val[:load_balancer_name]
     end
 
     validates_each(:task_definition_config, allow_nil: true) do |record, attr, val|

--- a/lib/broadside/version.rb
+++ b/lib/broadside/version.rb
@@ -1,3 +1,3 @@
 module Broadside
-  VERSION = '3.0.0-prerelease'.freeze
+  VERSION = '3.1.0-prerelease'.freeze
 end

--- a/spec/broadside/ecs/ecs_deploy_spec.rb
+++ b/spec/broadside/ecs/ecs_deploy_spec.rb
@@ -65,12 +65,12 @@ describe Broadside::EcsDeploy do
           end
 
           it 'sets up the ELB' do
-            #expect(Broadside::EcsManager).to receive(:create_load_balancer).with(elb_config.merge(load_balancer_name: elb_name), family)
-            expect(elb_stub).to receive(:create_load_balancer).with(
-              elb_config.merge(load_balancer_name: elb_name, tags: [{ key: 'family', value: family }])
-            )
             elb_stub.stub_responses(:create_load_balancer, load_balancer_response)
+            expect(elb_stub).to receive(:create_load_balancer).with(
+              elb_config.merge(name: elb_name, tags: [{ key: 'family', value: family }])
+            ).and_call_original
             expect(Broadside::EcsManager).to receive(:create_service).with(cluster, deploy.family, elb_service_config)
+
             expect { deploy.bootstrap}.to_not raise_error
           end
         end

--- a/spec/broadside/ecs/ecs_deploy_spec.rb
+++ b/spec/broadside/ecs/ecs_deploy_spec.rb
@@ -74,7 +74,7 @@ describe Broadside::EcsDeploy do
           it 'sets up the ELB' do
             elb_stub.stub_responses(:create_load_balancer, load_balancer_response)
             expect(elb_stub).to receive(:create_load_balancer).with(
-              elb_config.merge(name: family, tags: [{ key: 'family', value: family }])
+              elb_config.merge(name: family, scheme: 'internal', tags: [{ key: 'family', value: family }])
             ).and_call_original
             expect(ecs_stub).to receive(:create_service).with(service_config_args).and_call_original
 

--- a/spec/broadside/ecs/ecs_deploy_spec.rb
+++ b/spec/broadside/ecs/ecs_deploy_spec.rb
@@ -38,6 +38,19 @@ describe Broadside::EcsDeploy do
           expect(Broadside::EcsManager).to receive(:create_service).with(cluster, deploy.family, service_config)
           expect { deploy.bootstrap }.to_not raise_error
         end
+
+        context 'with a load_balancer_config' do
+          let(:elb_name) { 'my-load-balancer' }
+          let(:elb_config) { { subnets: [ 'subnet-xyz', 'subnet-abc'] } }
+          let(:elb_service_config) { service_config.merge(load_balancers: [{ load_balancer_name: elb_name }]) }
+          let(:local_target_config) { { service_config: elb_service_config, load_balancer_config: elb_config } }
+
+          it 'sets up the ELB' do
+            expect(Broadside::EcsManager).to receive(:create_load_balancer).with(elb_config.merge(load_balancer_name: elb_name), family)
+            expect(Broadside::EcsManager).to receive(:create_service).with(cluster, deploy.family, elb_service_config)
+            expect { deploy.bootstrap}.to_not raise_error
+          end
+        end
       end
 
       context 'with an existing service' do

--- a/spec/broadside/ecs/ecs_deploy_spec.rb
+++ b/spec/broadside/ecs/ecs_deploy_spec.rb
@@ -40,23 +40,23 @@ describe Broadside::EcsDeploy do
         end
 
         context 'with a load_balancer_config' do
-          let(:elb_config) { { subnets: [ 'subnet-xyz', 'subnet-abc'] } }
+          let(:elb_config) { { subnets: ['subnet-xyz', 'subnet-abc'] } }
           let(:local_target_config) { { service_config: service_config, load_balancer_config: elb_config } }
           let(:load_balancer_response) do
             {
               load_balancers: [
                 {
-                  availability_zones: [{ subnet_id: "notorious-subnet", zone_name: 'zone' }],
-                  canonical_hosted_zone_id: "ZEXAMPLE",
+                  availability_zones: [{ subnet_id: 'notorious-subnet', zone_name: 'zone' }],
+                  canonical_hosted_zone_id: 'EXAMPLE',
                   created_time: Time.now,
                   dns_name: 'dns',
-                  load_balancer_arn: "arn:aws:elasticloadbalancing:arnslength",
+                  load_balancer_arn: 'arn:aws:elasticloadbalancing:arnslength',
                   load_balancer_name: family,
-                  scheme: "internal",
+                  scheme: 'internal',
                   security_groups: [ 'security' ],
-                  state: { code: "provisioning" },
-                  type: "application",
-                  vpc_id: "vpc",
+                  state: { code: 'provisioning' },
+                  type: 'application',
+                  vpc_id: 'vpc',
                 }
               ]
             }
@@ -87,7 +87,7 @@ describe Broadside::EcsDeploy do
 
             expect(ecs_stub).to receive(:create_service).with(service_config_args).and_call_original
 
-            expect { deploy.bootstrap}.to_not raise_error
+            expect { deploy.bootstrap }.to_not raise_error
           end
         end
       end

--- a/spec/broadside/ecs/ecs_deploy_spec.rb
+++ b/spec/broadside/ecs/ecs_deploy_spec.rb
@@ -44,9 +44,35 @@ describe Broadside::EcsDeploy do
           let(:elb_config) { { subnets: [ 'subnet-xyz', 'subnet-abc'] } }
           let(:elb_service_config) { service_config.merge(load_balancers: [{ load_balancer_name: elb_name }]) }
           let(:local_target_config) { { service_config: elb_service_config, load_balancer_config: elb_config } }
+          let(:load_balancer_response) do
+            {
+              load_balancers: [
+                {
+                  availability_zones: [{ subnet_id: "notorious-subnet", zone_name: 'zone' }],
+                  canonical_hosted_zone_id: "ZEXAMPLE",
+                  created_time: Time.now,
+                  dns_name: 'dns',
+                  load_balancer_arn: "arn:aws:elasticloadbalancing:arnslength",
+                  load_balancer_name: elb_name,
+                  scheme: "internal",
+                  security_groups: [ 'security' ],
+                  state: { code: "provisioning" },
+                  type: "application",
+                  vpc_id: "vpc",
+                }
+              ]
+            }
+          end
 
           it 'sets up the ELB' do
-            expect(Broadside::EcsManager).to receive(:create_load_balancer).with(elb_config.merge(load_balancer_name: elb_name), family)
+            #expect(Broadside::EcsManager).to receive(:create_load_balancer).with(elb_config.merge(load_balancer_name: elb_name), family)
+    #        expect(elb_stub).to receive(:create_load_balancer).with(
+      #        elb_config.merge(load_balancer_name: elb_name, tags: [{ key: 'family', value: family }])
+        #    ).and_return(
+          #    load_balancer_response
+            #)
+
+            elb_stub.stub_responses(:create_load_balancer, load_balancer_response)
             expect(Broadside::EcsManager).to receive(:create_service).with(cluster, deploy.family, elb_service_config)
             expect { deploy.bootstrap}.to_not raise_error
           end

--- a/spec/broadside/ecs/ecs_deploy_spec.rb
+++ b/spec/broadside/ecs/ecs_deploy_spec.rb
@@ -66,12 +66,9 @@ describe Broadside::EcsDeploy do
 
           it 'sets up the ELB' do
             #expect(Broadside::EcsManager).to receive(:create_load_balancer).with(elb_config.merge(load_balancer_name: elb_name), family)
-    #        expect(elb_stub).to receive(:create_load_balancer).with(
-      #        elb_config.merge(load_balancer_name: elb_name, tags: [{ key: 'family', value: family }])
-        #    ).and_return(
-          #    load_balancer_response
-            #)
-
+            expect(elb_stub).to receive(:create_load_balancer).with(
+              elb_config.merge(load_balancer_name: elb_name, tags: [{ key: 'family', value: family }])
+            )
             elb_stub.stub_responses(:create_load_balancer, load_balancer_response)
             expect(Broadside::EcsManager).to receive(:create_service).with(cluster, deploy.family, elb_service_config)
             expect { deploy.bootstrap}.to_not raise_error

--- a/spec/broadside/ecs/ecs_deploy_spec.rb
+++ b/spec/broadside/ecs/ecs_deploy_spec.rb
@@ -76,9 +76,7 @@ describe Broadside::EcsDeploy do
             expect(elb_stub).to receive(:create_load_balancer).with(
               elb_config.merge(name: family, tags: [{ key: 'family', value: family }])
             ).and_call_original
-
             expect(ecs_stub).to receive(:create_service).with(service_config_args).and_call_original
-            #expect(Broadside::EcsManager).to receive(:create_service).with(cluster, deploy.family, service_config)
 
             expect { deploy.bootstrap}.to_not raise_error
           end

--- a/spec/broadside/ecs/ecs_manager_spec.rb
+++ b/spec/broadside/ecs/ecs_manager_spec.rb
@@ -65,7 +65,7 @@ describe Broadside::EcsManager do
     let(:elb_response) { { load_balancer_arn: elb_arn, load_balancer_name: elb_config[:name] } }
 
     it 'can create an ELB' do
-      described_class.create_load_balancer(elb_config, 'elb_family')
+      described_class.create_load_balancer(elb_config)
     end
 
     describe '#get_load_balancer_arn_by_name' do

--- a/spec/broadside/ecs/ecs_manager_spec.rb
+++ b/spec/broadside/ecs/ecs_manager_spec.rb
@@ -57,4 +57,31 @@ describe Broadside::EcsManager do
       expect(described_class.get_task_definition_arns('task')).to eq(task_definition_arns)
     end
   end
+
+  context 'load balancers' do
+    let(:elb_name) { 'my-load-balancer' }
+    let(:elb_config) { { name: elb_name,  subnets: [ 'subnet-xyz', 'subnet-abc'] } }
+    let(:elb_arn) { 'elb_arn' }
+    let(:elb_response) { { load_balancer_arn: elb_arn, load_balancer_name: elb_config[:name] } }
+
+    describe '#create_load_balancer' do
+      before do
+        elb_stub.stub_responses(:create_load_balancer, load_balancers: [elb_response])
+      end
+
+      it 'can create an ELB' do
+        expect(described_class.create_load_balancer(elb_config)).to eq(elb_response)
+      end
+    end
+
+    describe '#get_load_balancer_arn_by_name' do
+      before do
+        elb_stub.stub_responses(:describe_load_balancers, load_balancers: [elb_response])
+      end
+
+      it 'should find the relevant elb config' do
+        expect(described_class.get_load_balancer_arn_by_name(elb_name)).to eq(elb_arn)
+      end
+    end
+  end
 end

--- a/spec/broadside/ecs/ecs_manager_spec.rb
+++ b/spec/broadside/ecs/ecs_manager_spec.rb
@@ -60,7 +60,7 @@ describe Broadside::EcsManager do
 
   context 'load balancers' do
     let(:elb_name) { 'my-load-balancer' }
-    let(:elb_config) { { name: elb_name,  subnets: [ 'subnet-xyz', 'subnet-abc'] } }
+    let(:elb_config) { { name: elb_name,  subnets: ['subnet-xyz', 'subnet-abc'] } }
     let(:elb_arn) { 'elb_arn' }
     let(:elb_response) { { load_balancer_arn: elb_arn, load_balancer_name: elb_config[:name] } }
 

--- a/spec/broadside/ecs/ecs_manager_spec.rb
+++ b/spec/broadside/ecs/ecs_manager_spec.rb
@@ -64,14 +64,8 @@ describe Broadside::EcsManager do
     let(:elb_arn) { 'elb_arn' }
     let(:elb_response) { { load_balancer_arn: elb_arn, load_balancer_name: elb_config[:name] } }
 
-    describe '#create_load_balancer' do
-      before do
-        elb_stub.stub_responses(:create_load_balancer, load_balancers: [elb_response])
-      end
-
-      it 'can create an ELB' do
-        expect(described_class.create_load_balancer(elb_config)).to eq(elb_response)
-      end
+    it 'can create an ELB' do
+      described_class.create_load_balancer(elb_config, 'elb_family')
     end
 
     describe '#get_load_balancer_arn_by_name' do

--- a/spec/broadside/target_spec.rb
+++ b/spec/broadside/target_spec.rb
@@ -35,7 +35,9 @@ describe Broadside::Target do
     it_behaves_like 'valid_configuration?', true,  predeploy_commands: [%w(do something)]
     it_behaves_like 'valid_configuration?', true,  predeploy_commands: [%w(do something), %w(other command)]
 
-    it_behaves_like 'valid_configuration?', false,  task_definition_config: { container_definitions: %w(a b) }
+    it_behaves_like 'valid_configuration?', false, task_definition_config: { container_definitions: %w(a b) }
+
+    it_behaves_like 'valid_configuration?', true,  { service_config: { load_balancers: [{ load_balancer_name: 'elb' }] } }
   end
 
   describe '#ecs_env_vars' do

--- a/spec/broadside/target_spec.rb
+++ b/spec/broadside/target_spec.rb
@@ -37,13 +37,13 @@ describe Broadside::Target do
 
     it_behaves_like 'valid_configuration?', false, task_definition_config: { container_definitions: %w(a b) }
 
-    it_behaves_like 'valid_configuration?', true,  { service_config: { load_balancers: [{ load_balancer_name: 'x' }] } }
+    it_behaves_like 'valid_configuration?', true,  { service_config: { load_balancers: [load_balancer_name: 'x'] } }
     it_behaves_like 'valid_configuration?', true,  {
       service_config: {
-        load_balancers: [{ load_balancer_name: 'x' }]
+        load_balancers: [load_balancer_name: 'x']
       },
       load_balancer_config: {
-        subnets: ['abc', 'xyz']
+        subnets: %w(abc xyz)
       }
     }
   end

--- a/spec/broadside/target_spec.rb
+++ b/spec/broadside/target_spec.rb
@@ -37,7 +37,15 @@ describe Broadside::Target do
 
     it_behaves_like 'valid_configuration?', false, task_definition_config: { container_definitions: %w(a b) }
 
-    it_behaves_like 'valid_configuration?', true,  { service_config: { load_balancers: [{ load_balancer_name: 'elb' }] } }
+    it_behaves_like 'valid_configuration?', true,  { service_config: { load_balancers: [{ load_balancer_name: 'x' }] } }
+    it_behaves_like 'valid_configuration?', true,  {
+      service_config: {
+        load_balancers: [{ load_balancer_name: 'x' }]
+      },
+      load_balancer_config: {
+        subnets: ['abc', 'xyz']
+      }
+    }
   end
 
   describe '#ecs_env_vars' do

--- a/spec/support/ecs_shared_contexts.rb
+++ b/spec/support/ecs_shared_contexts.rb
@@ -3,10 +3,12 @@ shared_context 'ecs stubs' do
   let(:api_request_methods) { api_request_log.map(&:keys).flatten }
   let(:ecs_stub) { build_stub_aws_client(Aws::ECS::Client, api_request_log) }
   let(:ec2_stub) { build_stub_aws_client(Aws::EC2::Client, api_request_log) }
+  let(:elb_stub) { build_stub_aws_client(Aws::ElasticLoadBalancingV2::Client, api_request_log) }
 
   before(:each) do
     Broadside::EcsManager.instance_variable_set(:@ecs_client, ecs_stub)
     Broadside::EcsManager.instance_variable_set(:@ec2_client, ec2_stub)
+    Broadside::EcsManager.instance_variable_set(:@elb_client, elb_stub)
   end
 end
 


### PR DESCRIPTION
I took a crack at this. Right now the ELB is just named the same as the `family` and I haven't actually tested this.

Definitely doesn't need to be merged before we cut the 3.0 release.

Need more guidance/understanding of what to do about internal vs. external facing default and what to do about the ports.

fixes https://github.com/lumoslabs/broadside/issues/37