### PR TITLE
Fixed tag not set correctly on certain commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.0.2
+- fix absence of tag raising an error in certain cases
+
 # 3.0.1
 - `bootstrap` does not require a `--tag` option
 - `run` does not need require a `--instance`

--- a/lib/broadside/target.rb
+++ b/lib/broadside/target.rb
@@ -55,6 +55,7 @@ module Broadside
       @predeploy_commands     = config.delete(:predeploy_commands)
       @scale                  = config.delete(:scale)
       @service_config         = config.delete(:service_config)
+      @tag                    = config.delete(:tag)
       @task_definition_config = config.delete(:task_definition_config)
 
       @env_files = Array.wrap(config.delete(:env_files) || config.delete(:env_file)).map do |env_path|

--- a/lib/broadside/version.rb
+++ b/lib/broadside/version.rb
@@ -1,3 +1,3 @@
 module Broadside
-  VERSION = '3.0.1'.freeze
+  VERSION = '3.0.2'.freeze
 end

--- a/spec/broadside/target_spec.rb
+++ b/spec/broadside/target_spec.rb
@@ -3,6 +3,28 @@ require 'spec_helper'
 describe Broadside::Target do
   include_context 'deploy configuration'
 
+  describe '#initialize' do
+    let(:all_possible_options) do
+      {
+        bootstrap_commands: [],
+        cluster: 'some-cluster',
+        command: %w(some command),
+        docker_image: 'lumoslabs/hello',
+        env_file: '.env.test',
+        predeploy_commands: [],
+        scale: 9000,
+        service_config: {},
+        tag: 'latest',
+        task_definition_config: {}
+      }
+    end
+    let(:target) { described_class.new(test_target_name, all_possible_options) }
+
+    it 'should initialize without erroring using all possible options' do
+      expect { target }.to_not raise_error
+    end
+  end
+
   shared_examples 'valid_configuration?' do |succeeds, config_hash|
     let(:valid_options) { { scale: 100 } }
     let(:target) { described_class.new(test_target_name, valid_options.merge(config_hash)) }


### PR DESCRIPTION
addresses this error that @slpsys ran into doing a bootstrap:
```
broadside bootstrap --target web
E, [2017-02-24_18:45:51#67449] ERROR -- : Target web was configured with invalid options: {:tag=>"latest"} Run your last command with --help for more information.
```

@apurvis fyi