### PR TITLE
Adding --tag to bootstrap command in GLI specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.0.3
+- update of GLI specifications, adding on to 3.0.2
+
 # 3.0.2
 - fix absence of tag raising an error in certain cases
 

--- a/lib/broadside/gli/commands.rb
+++ b/lib/broadside/gli/commands.rb
@@ -24,6 +24,7 @@ end
 
 desc 'Bootstrap your service and task definition from the configured definition.'
 command :bootstrap do |bootstrap|
+  add_tag_flag(run)
   add_target_flag(bootstrap)
 
   bootstrap.action do |_, options, _|

--- a/lib/broadside/version.rb
+++ b/lib/broadside/version.rb
@@ -1,3 +1,3 @@
 module Broadside
-  VERSION = '3.0.2'.freeze
+  VERSION = '3.0.3'.freeze
 end


### PR DESCRIPTION
@matl33t I think this was actually the issue. I was still seeing the unknown option issue after bumping to 3.0.2. Updating the GLI command seemed to work nicely. LMK if there are specs that cover this that I should also update.

```
marc$ broadside --debug bootstrap --target web --tag latest
error: Unknown option --tag

NAME
    bootstrap - Bootstrap your service and task definition from the configured definition.

SYNOPSIS
    broadside [global options] bootstrap [command options]

COMMAND OPTIONS
    -t, --target=TARGET - Deployment target to use, e.g. production_web (required, default: none)
```