### PR TITLE
 WIP update-safe service config for load balancing

### DIFF
--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -152,7 +152,7 @@ module Broadside
         desired_count: scale,
         service: family,
         task_definition: task_definition_arn
-      }.deep_merge(@target.service_config || {}))
+      }.deep_merge(@target.update_safe_service_config || {}))
 
       unless update_service_response.successful?
         raise EcsError, "Failed to update service:\n#{update_service_response.pretty_inspect}"

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -152,7 +152,7 @@ module Broadside
         desired_count: scale,
         service: family,
         task_definition: task_definition_arn
-      }.deep_merge(@target.update_safe_service_config || {}))
+      }.deep_merge(@target.service_config_for_update || {}))
 
       unless update_service_response.successful?
         raise EcsError, "Failed to update service:\n#{update_service_response.pretty_inspect}"

--- a/lib/broadside/target.rb
+++ b/lib/broadside/target.rb
@@ -101,7 +101,7 @@ module Broadside
       )
 
       service_config.delete_if do |k, _|
-        attributes_disallowed_for_updates.contains?(k)
+        attributes_disallowed_for_updates.include?(k)
       end
     end
   end

--- a/lib/broadside/target.rb
+++ b/lib/broadside/target.rb
@@ -93,5 +93,16 @@ module Broadside
         Cluster: @cluster
       }
     end
+
+    def update_safe_service_config
+      attributes_disallowed_for_updates = %i(
+        role
+        load_balancers
+      )
+
+      service_config.delete_if do |k, _|
+        attributes_disallowed_for_updates.contains?(k)
+      end
+    end
   end
 end

--- a/lib/broadside/target.rb
+++ b/lib/broadside/target.rb
@@ -44,6 +44,14 @@ module Broadside
       record.errors.add(attr, 'is not an array of strings') unless val.is_a?(Array) && val.all? { |v| v.is_a?(String) }
     end
 
+    CREATE_ONLY_SERVICE_ATTRIBUTES = %i(
+      client_token
+      load_balancers
+      placement_constraints
+      placement_strategy
+      role
+    ).freeze
+
     def initialize(name, options = {})
       @name = name
 
@@ -94,15 +102,8 @@ module Broadside
       }
     end
 
-    def update_safe_service_config
-      attributes_disallowed_for_updates = %i(
-        role
-        load_balancers
-      )
-
-      service_config.delete_if do |k, _|
-        attributes_disallowed_for_updates.include?(k)
-      end
+    def service_config_for_update
+      service_config.except(CREATE_ONLY_SERVICE_ATTRIBUTES)
     end
   end
 end

--- a/lib/broadside/target.rb
+++ b/lib/broadside/target.rb
@@ -103,7 +103,7 @@ module Broadside
     end
 
     def service_config_for_update
-      service_config.try(:except, CREATE_ONLY_SERVICE_ATTRIBUTES)
+      service_config.try(:except, *CREATE_ONLY_SERVICE_ATTRIBUTES)
     end
   end
 end

--- a/lib/broadside/target.rb
+++ b/lib/broadside/target.rb
@@ -103,7 +103,7 @@ module Broadside
     end
 
     def service_config_for_update
-      service_config.except(CREATE_ONLY_SERVICE_ATTRIBUTES)
+      service_config.try(:except, CREATE_ONLY_SERVICE_ATTRIBUTES)
     end
   end
 end

--- a/lib/broadside/version.rb
+++ b/lib/broadside/version.rb
@@ -1,3 +1,3 @@
 module Broadside
-  VERSION = '3.0.2'.freeze
+  VERSION = '3.0.5'.freeze
 end

--- a/spec/broadside/target_spec.rb
+++ b/spec/broadside/target_spec.rb
@@ -3,23 +3,25 @@ require 'spec_helper'
 describe Broadside::Target do
   include_context 'deploy configuration'
 
-  describe '#initialize' do
-    let(:all_possible_options) do
-      {
-        bootstrap_commands: [],
-        cluster: 'some-cluster',
-        command: %w(some command),
-        docker_image: 'lumoslabs/hello',
-        env_file: '.env.test',
-        predeploy_commands: [],
-        scale: 9000,
-        service_config: {},
-        tag: 'latest',
-        task_definition_config: {}
-      }
-    end
-    let(:target) { described_class.new(test_target_name, all_possible_options) }
+  let(:base_possible_options) do
+    {
+      bootstrap_commands: [],
+      cluster: 'some-cluster',
+      command: %w(some command),
+      docker_image: 'lumoslabs/hello',
+      env_file: '.env.test',
+      predeploy_commands: [],
+      scale: 9000,
+      service_config: {},
+      tag: 'latest',
+      task_definition_config: {}
+    }
+  end
+  let(:all_possible_options) { base_possible_options }
+  let(:all_possible_options_with_create_only_service_options) { base_possible_options }
+  let(:target) { described_class.new(test_target_name, all_possible_options) }
 
+  describe '#initialize' do
     it 'should initialize without erroring using all possible options' do
       expect { target }.to_not raise_error
     end
@@ -46,7 +48,7 @@ describe Broadside::Target do
 
     it_behaves_like 'valid_configuration?', true,  env_files: nil
     it_behaves_like 'valid_configuration?', true,  env_files: 'file'
-    it_behaves_like 'valid_configuration?', true,  env_files: ['file', 'file2']
+    it_behaves_like 'valid_configuration?', true,  env_files: %w(file file2)
 
     it_behaves_like 'valid_configuration?', true,  command: nil
     it_behaves_like 'valid_configuration?', true,  command: %w(do something)
@@ -76,7 +78,7 @@ describe Broadside::Target do
       let(:expected_env_vars) do
         [
           { 'name' => 'TEST_KEY1', 'value' => 'TEST_VALUE1' },
-          { 'name' => 'TEST_KEY2', 'value' => 'TEST_VALUE2'}
+          { 'name' => 'TEST_KEY2', 'value' => 'TEST_VALUE2' }
         ]
       end
 
@@ -94,6 +96,34 @@ describe Broadside::Target do
       end
 
       it_behaves_like 'successfully loaded env_files'
+    end
+  end
+
+  describe '#service_config_for_update' do
+    context 'with no service config' do
+      it 'does not raise an error' do
+        expect { target }.to_not raise_error
+      end
+    end
+
+    shared_examples 'accessor for update-safe service config parameters' do
+      it 'does not raise an error' do
+        expect { target }.to_not raise_error
+      end
+
+      it 'returns the basic serivce config parameters' do
+        expect(target.service_config).to eq(base_possible_options[:service_config])
+      end
+    end
+
+    context 'with a normal service config' do
+      it_behaves_like 'accessor for update-safe service config parameters'
+    end
+
+    context 'with a service config containing create-only parameters' do
+      let(:all_possible_options) { all_possible_options_with_create_only_service_options }
+
+      it_behaves_like 'accessor for update-safe service config parameters'
     end
   end
 end


### PR DESCRIPTION
This is definitely part of #37; create_service needs service config information that tells it about the intended load balancer, and the load balancer info _requires_ an IAM role. 

The issue is that while `create-service` needs it, `update-service` not only can't change it, but as a result, _will error out if it's present_. So we need one copy with, one copy without.

This doesn't have specs [yet], and also is probably not a complete list [yet].