### PR TITLE
Make --tag optional during bootstrap command; raise errors as needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 3.0.6
+- `--tag` option is optional while bootstrapping
+
+# 3.0.5
+- Make `update_service` work correctly for services configured with load balancers
+
+# 3.0.4
+- `--tag` option required during bootstrapping
+
 # 3.0.3
 - update of GLI specifications, adding on to 3.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 3.0.6
-- `--tag` option is optional while bootstrapping
+- `--tag` option is optional while bootstrapping if you already have a configured `task_definition`
 
 # 3.0.5
 - Make `update_service` work correctly for services configured with load balancers

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -26,10 +26,9 @@ module Broadside
     def bootstrap
       if EcsManager.get_latest_task_definition_arn(family)
         info "Task definition for #{family} already exists."
-      elsif @target.bootstrap_commands && !@target.tag
-        raise ConfigurationError, 'Bootstrapping a task_definition requires a --tag option'
       else
         raise ConfigurationError, "No :task_definition_config for #{family}" unless @target.task_definition_config
+        raise ConfigurationError, 'Bootstrapping a task_definition requires a --tag option' unless @target.tag
         info "Creating an initial task definition for '#{family}' from the config..."
 
         EcsManager.ecs.register_task_definition(

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -26,7 +26,7 @@ module Broadside
     def bootstrap
       if EcsManager.get_latest_task_definition_arn(family)
         info "Task definition for #{family} already exists."
-      if @target.bootstrap_commands && !@target.tag
+      elsif @target.bootstrap_commands && !@target.tag
         raise ConfigurationError, 'Bootstraping a task_definition requires a --tag option'
       else
         raise ConfigurationError, "No :task_definition_config for #{family}" unless @target.task_definition_config

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -27,7 +27,7 @@ module Broadside
       if EcsManager.get_latest_task_definition_arn(family)
         info "Task definition for #{family} already exists."
       elsif @target.bootstrap_commands && !@target.tag
-        raise ConfigurationError, 'Bootstraping a task_definition requires a --tag option'
+        raise ConfigurationError, 'Bootstrapping a task_definition requires a --tag option'
       else
         raise ConfigurationError, "No :task_definition_config for #{family}" unless @target.task_definition_config
         info "Creating an initial task definition for '#{family}' from the config..."

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -26,6 +26,8 @@ module Broadside
     def bootstrap
       if EcsManager.get_latest_task_definition_arn(family)
         info "Task definition for #{family} already exists."
+      if @target.bootstrap_commands && !@target.tag
+        raise ConfigurationError, 'Bootstraping a task_definition requires a --tag option'
       else
         raise ConfigurationError, "No :task_definition_config for #{family}" unless @target.task_definition_config
         info "Creating an initial task definition for '#{family}' from the config..."

--- a/lib/broadside/gli/commands.rb
+++ b/lib/broadside/gli/commands.rb
@@ -25,6 +25,7 @@ end
 desc 'Bootstrap your service and task definition from the configured definition.'
 command :bootstrap do |bootstrap|
   add_target_flag(bootstrap)
+  bootstrap.arg 'tag' :optional
 
   bootstrap.action do |_, options, _|
     Broadside::EcsDeploy.new(options).bootstrap

--- a/lib/broadside/gli/commands.rb
+++ b/lib/broadside/gli/commands.rb
@@ -24,8 +24,8 @@ end
 
 desc 'Bootstrap your service and task definition from the configured definition.'
 command :bootstrap do |bootstrap|
-  add_target_flag(bootstrap)
   bootstrap.arg 'tag' :optional
+  add_target_flag(bootstrap)
 
   bootstrap.action do |_, options, _|
     Broadside::EcsDeploy.new(options).bootstrap

--- a/lib/broadside/gli/commands.rb
+++ b/lib/broadside/gli/commands.rb
@@ -25,7 +25,9 @@ end
 desc 'Bootstrap your service and task definition from the configured definition.'
 command :bootstrap do |bootstrap|
   bootstrap.desc 'Optionally configured tag - without it you cannot bootstrap a task_definition'
-  bootstrap.arg 'tag' :optional
+  bootstrap.arg_name 'TAG'
+  bootstrap.flag 'tag', :optional
+
   add_target_flag(bootstrap)
 
   bootstrap.action do |_, options, _|

--- a/lib/broadside/version.rb
+++ b/lib/broadside/version.rb
@@ -1,3 +1,3 @@
 module Broadside
-  VERSION = '3.0.5'.freeze
+  VERSION = '3.0.6'.freeze
 end


### PR DESCRIPTION
https://github.com/lumoslabs/broadside/pull/80 requires the `--tag` every time bootstrap is run.  

inside `bootstrap` though, the only part that _requires_ the `tag` option is the creation of the `task_definition`.  once the task defintion is up, the service can continue being setup without the option.


so.... i'm pretty unsure if @slpsys 's solution over on https://github.com/lumoslabs/broadside/pull/80 is overkill (because `--tag` isn't always needed, depending on the state of your services and task_definitions), or if this PR is underkill in that it lets you get away with doing stuff with less typing in more obscure situations (by "obscure" i mean only very rarely do people find themselves with a well formatted `task_defintion` and no service definition at all)


(maybe the long termer option is to have bootstrap tear down the existing service and start over.)