### PR TITLE
Spec for the GLI commands file being parseable

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,4 +104,15 @@ For full application setup, see the [detailed instructions in the wiki](https://
 Use the `--debug` switch to enable stacktraces and debug output.
 
 ## Contributing
-Pull requests, bug reports, and feature suggestions are welcome! Before starting on a contribution, we recommend opening an issue or replying to an existing one to give others some initial context on the work needing to be done.
+Pull requests, bug reports, and feature suggestions are welcome!
+
+Before starting on a contribution, we recommend opening an issue or replying to an existing one to give others some initial context on the work needing to be done.
+
+**Specs must pass on pull requests for them to be considered.**
+
+### Running Specs
+Broadside has a lot of tests for most of its behaviors - just run
+```
+bundle exec rspec
+```
+in the broadside directory.  Don't open pull requests without passing specs.

--- a/spec/broadside_spec.rb
+++ b/spec/broadside_spec.rb
@@ -3,6 +3,13 @@ require 'spec_helper'
 describe Broadside do
   include_context 'deploy configuration'
 
+  it 'should be able to display the help menu' do
+    silence_warnings do
+      exit_value = system('bundle exec broadside --help >/dev/null')
+      expect(exit_value).to be_truthy
+    end
+  end
+
   describe '#load_config_file' do
     it 'calls load for both the system and app config files' do
       expect(Broadside).to receive(:load).with(system_config_path).ordered


### PR DESCRIPTION
This is just a spec that would have caught the error in https://github.com/lumoslabs/broadside/pull/80

if GLI can't parse its files, the return value will not be truthy.  in general the fact that changes to the GLI files have no specs has always been a bit of a concern because we have only been catching them by manually running the commands; this solves a lot of that uncertainty