### PR TITLE
Got a warning when building the gem

### DIFF
--- a/broadside.gemspec
+++ b/broadside.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'gli', '~> 2.13'
   spec.add_dependency 'tty', '~> 0.5'
 
-  spec.add_development_dependency 'rspec', '~> 3.4.0'
+  spec.add_development_dependency 'rspec', '~> 3.4'
   spec.add_development_dependency 'bundler', '~> 1.9'
 end


### PR DESCRIPTION
```
marc-mbp-2:broadside marc$ gem build broadside.gemspec
WARNING:  pessimistic dependency on rspec (~> 3.4.0, development) may be overly strict
  if rspec is semantically versioned, use:
    add_development_dependency 'rspec', '~> 3.4', '>= 3.4.0'
```