### PR TITLE
Remove --optionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.0.7
+- `--tag` option for `bootstrap` also was named `--optional` (whoops)
+
 # 3.0.6
 - `--tag` option is optional while bootstrapping if you already have a configured `task_definition`
 

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -28,7 +28,7 @@ module Broadside
         info "Task definition for #{family} already exists."
       else
         raise ConfigurationError, "No :task_definition_config for #{family}" unless @target.task_definition_config
-        raise ConfigurationError, 'Bootstrapping a task_definition requires a --tag option' unless @target.tag
+        raise ConfigurationError, 'Bootstrapping a task_definition requires a :tag for the image' unless @target.tag
         info "Creating an initial task definition for '#{family}' from the config..."
 
         EcsManager.ecs.register_task_definition(

--- a/lib/broadside/gli/commands.rb
+++ b/lib/broadside/gli/commands.rb
@@ -22,10 +22,14 @@ def add_command_flags(cmd)
   add_target_flag(cmd)
 end
 
+def add_deploy_flags(cmd)
+  add_tag_flag(cmd)
+  add_target_flag(cmd)
+end
+
 desc 'Bootstrap your service and task definition from the configured definition.'
 command :bootstrap do |bootstrap|
-  add_tag_flag(bootstrap)
-  add_target_flag(bootstrap)
+  add_deploy_flags(bootstrap)
 
   bootstrap.action do |_, options, _|
     Broadside::EcsDeploy.new(options).bootstrap
@@ -57,8 +61,7 @@ command :run do |run|
   run.arg_name 'COMMAND'
   run.flag [:command], type: Array
 
-  add_tag_flag(run)
-  add_target_flag(run)
+  add_deploy_flags(run)
 
   run.action do |_, options, _|
     EcsDeploy.new(options).run_commands([options[:command]], started_by: 'run')
@@ -101,8 +104,7 @@ desc 'Deploy your application.'
 command :deploy do |d|
   d.desc 'Deploys WITHOUT running predeploy commands'
   d.command :short do |short|
-    add_tag_flag(short)
-    add_target_flag(short)
+    add_deploy_flags(short)
 
     short.action do |_, options, _|
       Broadside::EcsDeploy.new(options).short
@@ -111,8 +113,7 @@ command :deploy do |d|
 
   d.desc 'Deploys WITH running predeploy commands'
   d.command :full do |full|
-    add_tag_flag(full)
-    add_target_flag(full)
+    add_deploy_flags(full)
 
     full.action do |_, options, _|
       Broadside::EcsDeploy.new(options).full

--- a/lib/broadside/gli/commands.rb
+++ b/lib/broadside/gli/commands.rb
@@ -24,10 +24,7 @@ end
 
 desc 'Bootstrap your service and task definition from the configured definition.'
 command :bootstrap do |bootstrap|
-  bootstrap.desc 'Optionally configured tag - without it you cannot bootstrap a task_definition'
-  bootstrap.arg_name 'TAG'
-  bootstrap.flag 'tag', :optional
-
+  add_tag_flag(bootstrap)
   add_target_flag(bootstrap)
 
   bootstrap.action do |_, options, _|

--- a/lib/broadside/version.rb
+++ b/lib/broadside/version.rb
@@ -1,3 +1,3 @@
 module Broadside
-  VERSION = '3.0.6'.freeze
+  VERSION = '3.0.7'.freeze
 end


### PR DESCRIPTION
 flags are optional by default and are required by `required: true`, not `:optional`.  my bad.

(the way it was before, it just allowed `--optional` to mean the same as `--tag`)