### PR TITLE
Fix bootstrap tag

### DIFF
--- a/lib/broadside/deploy.rb
+++ b/lib/broadside/deploy.rb
@@ -4,9 +4,11 @@ module Broadside
 
     attr_reader :target
 
+    delegate :tag, to: :target
+
     def initialize(options = {})
       @target = Broadside.config.get_target_by_name!(options[:target])
-      @tag = options[:tag] || @target.tag
+      @target.tag ||= options[:tag]
     end
 
     private

--- a/lib/broadside/deploy.rb
+++ b/lib/broadside/deploy.rb
@@ -4,8 +4,6 @@ module Broadside
 
     attr_reader :target
 
-    delegate :tag, to: :target
-
     def initialize(options = {})
       @target = Broadside.config.get_target_by_name!(options[:target])
       @tag = options[:tag] || @target.tag

--- a/lib/broadside/deploy.rb
+++ b/lib/broadside/deploy.rb
@@ -8,7 +8,7 @@ module Broadside
 
     def initialize(options = {})
       @target = Broadside.config.get_target_by_name!(options[:target])
-      @target.tag = options[:tag] if options[:tag]
+      @tag = options[:tag] || @target.tag
     end
 
     private

--- a/lib/broadside/deploy.rb
+++ b/lib/broadside/deploy.rb
@@ -8,7 +8,7 @@ module Broadside
 
     def initialize(options = {})
       @target = Broadside.config.get_target_by_name!(options[:target])
-      @target.tag ||= options[:tag]
+      @target.tag = options[:tag] if options[:tag]
     end
 
     private

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -28,7 +28,7 @@ module Broadside
         info "Task definition for #{family} already exists."
       else
         raise ConfigurationError, "No :task_definition_config for #{family}" unless @target.task_definition_config
-        raise ConfigurationError, 'Bootstrapping a task_definition requires a :tag for the image' unless @target.tag
+        raise ConfigurationError, 'Bootstrapping a task_definition requires a :tag for the image' unless @tag
         info "Creating an initial task definition for '#{family}' from the config..."
 
         EcsManager.ecs.register_task_definition(

--- a/lib/broadside/gli/commands.rb
+++ b/lib/broadside/gli/commands.rb
@@ -14,7 +14,7 @@ def add_instance_flag(cmd)
   cmd.desc '0-based index into the array of running instances'
   cmd.default_value 0
   cmd.arg_name 'INSTANCE'
-  cmd.flag [:n, :instance], type: Fixnum
+  cmd.flag [:n, :instance], type: Integer
 end
 
 def add_command_flags(cmd)
@@ -38,7 +38,7 @@ end
 
 desc 'Gives an overview of all of the deploy targets'
 command :targets do |targets|
-  targets.action do |_, options, _|
+  targets.action do |_, _, _|
     Broadside::Command.targets
   end
 end
@@ -73,7 +73,7 @@ command :logtail do |logtail|
   logtail.desc 'Number of lines to tail'
   logtail.default_value Broadside::Command::DEFAULT_TAIL_LINES
   logtail.arg_name 'TAIL_LINES'
-  logtail.flag [:l, :lines], type: Fixnum
+  logtail.flag [:l, :lines], type: Integer
 
   add_command_flags(logtail)
 
@@ -124,7 +124,7 @@ command :deploy do |d|
   d.command :scale do |scale|
     scale.desc 'Specify a new scale for application'
     scale.arg_name 'NUM'
-    scale.flag [:s, :scale], type: Fixnum
+    scale.flag [:s, :scale], type: Integer
 
     add_target_flag(scale)
 
@@ -137,7 +137,7 @@ command :deploy do |d|
   d.command :rollback do |rollback|
     rollback.desc 'Number of releases to rollback'
     rollback.arg_name 'COUNT'
-    rollback.flag [:r, :rollback], type: Fixnum
+    rollback.flag [:r, :rollback], type: Integer
 
     add_target_flag(rollback)
 

--- a/lib/broadside/version.rb
+++ b/lib/broadside/version.rb
@@ -1,3 +1,3 @@
 module Broadside
-  VERSION = '3.0.8'.freeze
+  VERSION = '3.0.9'.freeze
 end


### PR DESCRIPTION
This should address #90. `options[:tag]` contains the target from the command-line arg, but `@target.tag` is [what's actually being used](https://github.com/lumoslabs/broadside/blob/c9a01fe18a357f09c8a195ff915a687e80b5ec1c/lib/broadside/ecs/ecs_deploy.rb#L31)

cc @dtboctor 