### PR TITLE
Fix the scale log output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.0.10
+-- Fix log output when using `scale` command
+
 # 3.0.9
 -- Fixing `--tag` handling on `bootstrap` to correctly pass assertion
 

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -67,7 +67,7 @@ module Broadside
     end
 
     def scale(options = {})
-      info "Rescaling #{family} with scale=#{options[:scale]}..."
+      info "Rescaling #{family} with scale=#{options[:scale] || @target.scale}..."
       update_service(options)
       info 'Rescaling complete.'
     end

--- a/lib/broadside/ecs/ecs_deploy.rb
+++ b/lib/broadside/ecs/ecs_deploy.rb
@@ -67,7 +67,7 @@ module Broadside
     end
 
     def scale(options = {})
-      info "Rescaling #{family} with scale=#{@scale}..."
+      info "Rescaling #{family} with scale=#{options[:scale]}..."
       update_service(options)
       info 'Rescaling complete.'
     end

--- a/lib/broadside/version.rb
+++ b/lib/broadside/version.rb
@@ -1,3 +1,3 @@
 module Broadside
-  VERSION = '3.0.9'.freeze
+  VERSION = '3.0.10'.freeze
 end


### PR DESCRIPTION
the log output was unhelpful

```
Mon May 22 11:57:55 [9:0]$ broadside deploy scale --target=user_devices --scale=0
I, [2017-05-22_11:58:14#11471]  INFO -- : Rescaling events_user_devices with scale=..
```