### PR TITLE
Add the ability to execute bash commands on remote containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-# 3.1.4
+# 3.2.0
+-- Add ability to execute a bash command on a container
 -- Output actual bash command being run when log level is debug.
 
 # 3.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.1.4
+-- Output actual bash command being run when log level is debug.
+
 # 3.1.3
 -- Better error messaging when trying to bash/ssh/etc to an instance_index that doesn't exist
 

--- a/lib/broadside/command.rb
+++ b/lib/broadside/command.rb
@@ -109,10 +109,18 @@ module Broadside
       def bash(options)
         target = Broadside.config.get_target_by_name!(options[:target])
         ip = get_running_instance_ip!(target, *options[:instance])
-        info "Running bash for running container at #{ip}..."
+        cmd = "docker exec -i -t `#{docker_ps_cmd(target.family)}`"
+        tty = !options[:command]
 
-        cmd = "docker exec -i -t `#{docker_ps_cmd(target.family)}` bash"
-        system_exec(Broadside.config.ssh_cmd(ip, tty: true) + " '#{cmd}'")
+        if options[:command]
+          info "Executing #{options[:command]} on running container at #{ip}..."
+          cmd = "#{cmd} #{options[:command]}"
+        else
+          info "Running bash for running container at #{ip}..."
+          cmd = "#{cmd} bash"
+        end
+
+        system_exec(Broadside.config.ssh_cmd(ip, tty: tty) + " '#{cmd}'")
       end
 
       private

--- a/lib/broadside/command.rb
+++ b/lib/broadside/command.rb
@@ -95,7 +95,7 @@ module Broadside
         info "Tailing logs for running container at #{ip}..."
 
         cmd = "docker logs -f --tail=#{lines} `#{docker_ps_cmd(target.family)}`"
-        exec(Broadside.config.ssh_cmd(ip) + " '#{cmd}'")
+        system_exec(Broadside.config.ssh_cmd(ip) + " '#{cmd}'")
       end
 
       def ssh(options)
@@ -103,7 +103,7 @@ module Broadside
         ip = get_running_instance_ip!(target, *options[:instance])
         info "Establishing SSH connection to #{ip}..."
 
-        exec(Broadside.config.ssh_cmd(ip))
+        system_exec(Broadside.config.ssh_cmd(ip))
       end
 
       def bash(options)
@@ -112,10 +112,15 @@ module Broadside
         info "Running bash for running container at #{ip}..."
 
         cmd = "docker exec -i -t `#{docker_ps_cmd(target.family)}` bash"
-        exec(Broadside.config.ssh_cmd(ip, tty: true) + " '#{cmd}'")
+        system_exec(Broadside.config.ssh_cmd(ip, tty: true) + " '#{cmd}'")
       end
 
       private
+
+      def system_exec(cmd)
+        debug "Executing: #{cmd}"
+        exec(cmd)
+      end
 
       def get_running_instance_ip!(target, instance_index = 0)
         EcsManager.check_service_and_task_definition_state!(target)

--- a/lib/broadside/command.rb
+++ b/lib/broadside/command.rb
@@ -109,18 +109,17 @@ module Broadside
       def bash(options)
         target = Broadside.config.get_target_by_name!(options[:target])
         ip = get_running_instance_ip!(target, *options[:instance])
-        cmd = "docker exec -i -t `#{docker_ps_cmd(target.family)}`"
-        tty = !options[:command]
+        cmd = "docker exec -i -t `#{docker_ps_cmd(target.family)}` "
 
         if options[:command]
           info "Executing #{options[:command]} on running container at #{ip}..."
-          cmd = "#{cmd} #{options[:command]}"
+          cmd += options[:command]
         else
           info "Running bash for running container at #{ip}..."
-          cmd = "#{cmd} bash"
+          cmd += 'bash'
         end
 
-        system_exec(Broadside.config.ssh_cmd(ip, tty: tty) + " '#{cmd}'")
+        system_exec(Broadside.config.ssh_cmd(ip, tty: !options[:command]) + " '#{cmd}'")
       end
 
       private

--- a/lib/broadside/command.rb
+++ b/lib/broadside/command.rb
@@ -6,6 +6,7 @@ module Broadside
   module Command
     extend LoggingUtils
 
+    BASH = 'bash'.freeze
     DEFAULT_TAIL_LINES = 10
 
     class << self
@@ -107,19 +108,13 @@ module Broadside
       end
 
       def bash(options)
+        command = options[:command] || BASH
         target = Broadside.config.get_target_by_name!(options[:target])
         ip = get_running_instance_ip!(target, *options[:instance])
-        cmd = "docker exec -i -t `#{docker_ps_cmd(target.family)}` "
+        cmd = "docker exec -i -t `#{docker_ps_cmd(target.family)}` #{command}"
+        info "Executing #{command} on running container at #{ip}..."
 
-        if options[:command]
-          info "Executing #{options[:command]} on running container at #{ip}..."
-          cmd += options[:command]
-        else
-          info "Running bash for running container at #{ip}..."
-          cmd += 'bash'
-        end
-
-        system_exec(Broadside.config.ssh_cmd(ip, tty: !options[:command]) + " '#{cmd}'")
+        system_exec(Broadside.config.ssh_cmd(ip, tty: command == BASH) + " '#{cmd}'")
       end
 
       private

--- a/lib/broadside/gli/commands.rb
+++ b/lib/broadside/gli/commands.rb
@@ -91,9 +91,13 @@ command :ssh do |ssh|
   end
 end
 
-desc 'Establish a shell inside a running container.'
+desc 'Establish a shell or run a bash command inside a running container.'
 command :bash do |bash|
   add_command_flags(bash)
+
+  bash.desc 'bash command to run (wrap argument in quotes)'
+  bash.arg_name 'BASH_COMMAND'
+  bash.flag [:c, :command], type: Array
 
   bash.action do |_, options, _|
     Broadside::Command.bash(options)

--- a/lib/broadside/version.rb
+++ b/lib/broadside/version.rb
@@ -1,3 +1,3 @@
 module Broadside
-  VERSION = '3.1.3'.freeze
+  VERSION = '3.1.4'.freeze
 end

--- a/lib/broadside/version.rb
+++ b/lib/broadside/version.rb
@@ -1,3 +1,3 @@
 module Broadside
-  VERSION = '3.1.4'.freeze
+  VERSION = '3.2.0'.freeze
 end


### PR DESCRIPTION
This change adds the `--command` flag to the `bash` command to execute a bash command on the remote container.  The motivating reason is so we can get on the container and run `git pull` to deploy airflow.

PR Also logs local bash commands at debug level