### PR TITLE
Use a separate "execute" for running bash commands in containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 3.2.1
--- Always turn on TTY interaction when running remote commands; make the bash command a string
+-- Always turn on TTY interaction when running remote commands; fix bug with command being array
 
 # 3.2.0
 -- Add ability to execute a bash command on a container

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 3.3.0
+-- Add `execute` command to execute arbitrary bash inside a running container
+-- Add `--all` flag to `execute` to run a command on all containers
 -- Always turn on TTY interaction when running remote commands.
--- Add `bash --all` to execute a command on all containers
 -- Fix bug with command being an array instead of string
 
 # 3.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 3.2.1
--- Always turn on TTY interaction when running remote commands; fix bug with command being array
+-- Fix bug with command being array
+-- Always turn on TTY interaction when running remote commands.
 
 # 3.2.0
 -- Add ability to execute a bash command on a container

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.2.1
+-- Always turn on TTY interaction when running remote commands; make the bash command a string
+
 # 3.2.0
 -- Add ability to execute a bash command on a container
 -- Output actual bash command being run when log level is debug.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# 3.2.1
--- Fix bug with command being array
+# 3.3.0
 -- Always turn on TTY interaction when running remote commands.
+-- Add `bash --all` to execute a command on all containers
+-- Fix bug with command being an array instead of string
 
 # 3.2.0
 -- Add ability to execute a bash command on a container

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Broadside does _not_ attempt to handle operational tasks like infrastructure set
 - **Inject** environment variables into ECS containers from local configuration files
 - **Launch a bash shell** on container in the cluster
 - **SSH** directly onto a host running a container
-- **Execute** an arbitrary shell command on a container
+- **Execute** an arbitrary shell command on a container (or all containers)
 - **Tail logs** of a running container
 - **Scale** an existing deployment on the fly
 
@@ -31,17 +31,17 @@ Broadside.configure do |config|
   config.targets = {
     production_web: {
       scale: 7,
-      command: ['bundle', 'exec', 'unicorn', '-c', 'config/unicorn.conf.rb'],
+      command: %w(bundle exec unicorn -c config/unicorn.conf.rb),
       env_file: '.env.production'
       predeploy_commands: [
-        ['bundle', 'exec', 'rake', 'db:migrate'],
-        ['bundle', 'exec', 'rake', 'data:migrate']
+        %w(bundle exec rake db:migrate),
+        %w(bundle exec rake data:migrate)
       ]
     },
     # If you have multiple images or clusters, you can configure them per target
     staging_web: {
       scale: 1,
-      command: ['bundle', 'exec', 'puma'],
+      command: %w(bundle exec puma),
       env_file: '.env.staging',
       tag: 'latest',                                # Set a default tag for this target
       cluster: 'staging-cluster',                   # Overrides config.aws.ecs_default_cluster
@@ -49,7 +49,7 @@ Broadside.configure do |config|
     },
     json_stream: {
       scale: 1,
-      command: ['java', '-cp', '*:.', 'path.to.MyClass'],
+      command: %w(java -cp *:. path.to.MyClass),
       # This target has a task_definition and service config which you use to bootstrap a new AWS Service
       service_config: { deployment_configuration: { minimum_healthy_percent: 0.5 } },
       task_definition_config: { container_definitions: [ { cpu: 1, memory: 2000, } ] }

--- a/lib/broadside/command.rb
+++ b/lib/broadside/command.rb
@@ -114,7 +114,6 @@ module Broadside
         cmd = "docker exec -i -t `#{docker_ps_cmd(target.family)}` #{command}"
 
         if options[:all]
-          raise Error, "You can't specify an instance and --all at the same time."
           ips = running_instances(target)
         else
           ips = [get_running_instance_ip!(target, *options[:instance])]

--- a/lib/broadside/command.rb
+++ b/lib/broadside/command.rb
@@ -109,7 +109,16 @@ module Broadside
       end
 
       def bash(options)
-        command = options[:command] || BASH
+        target = Broadside.config.get_target_by_name!(options[:target])
+        cmd = "docker exec -i -t `#{docker_ps_cmd(target.family)}` #{BASH}"
+        ip = get_running_instance_ip!(target, *options[:instance])
+        info "Executing #{BASH} on running container at #{ip}..."
+
+        system_exec(Broadside.config.ssh_cmd(ip, tty: true) + " '#{cmd}'")
+      end
+
+      def execute(options)
+        command = options[:command]
         target = Broadside.config.get_target_by_name!(options[:target])
         cmd = "docker exec -i -t `#{docker_ps_cmd(target.family)}` #{command}"
         ips = options[:all] ? running_instances(target) : [get_running_instance_ip!(target, *options[:instance])]

--- a/lib/broadside/command.rb
+++ b/lib/broadside/command.rb
@@ -122,7 +122,9 @@ module Broadside
 
         ips.each do |ip|
           info "Executing '#{command}' on running container at #{ip}..."
-          system_exec(Broadside.config.ssh_cmd(ip, tty: true) + " '#{cmd}'")
+          output = %x[#{Broadside.config.ssh_cmd(ip, tty: true) + " '#{cmd}'"}]
+          puts "OUTPUT:\n #{output}"
+          #system_exec(Broadside.config.ssh_cmd(ip, tty: true) + " '#{cmd}'")
         end
       end
 

--- a/lib/broadside/command.rb
+++ b/lib/broadside/command.rb
@@ -112,12 +112,7 @@ module Broadside
         command = options[:command] || BASH
         target = Broadside.config.get_target_by_name!(options[:target])
         cmd = "docker exec -i -t `#{docker_ps_cmd(target.family)}` #{command}"
-
-        if options[:all]
-          ips = running_instances(target)
-        else
-          ips = [get_running_instance_ip!(target, *options[:instance])]
-        end
+        ips = options[:all] ? running_instances(target) : [get_running_instance_ip!(target, *options[:instance])]
 
         ips.each do |ip|
           info "Executing '#{command}' on running container at #{ip}..."

--- a/lib/broadside/command.rb
+++ b/lib/broadside/command.rb
@@ -118,8 +118,6 @@ module Broadside
           ips = [get_running_instance_ip!(target, *options[:instance])]
         end
 
-        debug "Running IPs: #{ips}"
-
         ips.each do |ip|
           info "Executing '#{command}' on running container at #{ip}..."
           puts %x[#{Broadside.config.ssh_cmd(ip, tty: true) + " '#{cmd}'"}]

--- a/lib/broadside/command.rb
+++ b/lib/broadside/command.rb
@@ -114,6 +114,7 @@ module Broadside
         cmd = "docker exec -i -t `#{docker_ps_cmd(target.family)}` #{command}"
 
         if options[:all]
+          raise Error, "You can't specify an instance and --all at the same time."
           ips = running_instances(target)
         else
           ips = [get_running_instance_ip!(target, *options[:instance])]

--- a/lib/broadside/command.rb
+++ b/lib/broadside/command.rb
@@ -122,9 +122,7 @@ module Broadside
 
         ips.each do |ip|
           info "Executing '#{command}' on running container at #{ip}..."
-          output = %x[#{Broadside.config.ssh_cmd(ip, tty: true) + " '#{cmd}'"}]
-          puts "OUTPUT:\n #{output}"
-          #system_exec(Broadside.config.ssh_cmd(ip, tty: true) + " '#{cmd}'")
+          puts %x[#{Broadside.config.ssh_cmd(ip, tty: true) + " '#{cmd}'"}]
         end
       end
 

--- a/lib/broadside/command.rb
+++ b/lib/broadside/command.rb
@@ -118,6 +118,8 @@ module Broadside
           ips = [get_running_instance_ip!(target, *options[:instance])]
         end
 
+        debug "Running IPs: #{ips}"
+
         ips.each do |ip|
           info "Executing '#{command}' on running container at #{ip}..."
           system_exec(Broadside.config.ssh_cmd(ip, tty: true) + " '#{cmd}'")

--- a/lib/broadside/command.rb
+++ b/lib/broadside/command.rb
@@ -121,11 +121,7 @@ module Broadside
 
         ips.each do |ip|
           info "Executing '#{command}' on running container at #{ip}..."
-
-          Open3.popen3(Broadside.config.ssh_cmd(ip, tty: true) + " '#{cmd}'") do |_, stdout, stderr, _|
-            puts stdout.read
-            puts stderr.read
-          end
+          Open3.popen3(Broadside.config.ssh_cmd(ip, tty: true) + " '#{cmd}'") { |_, stdout, _, _| puts stdout.read }
         end
       end
 

--- a/lib/broadside/command.rb
+++ b/lib/broadside/command.rb
@@ -114,7 +114,7 @@ module Broadside
         cmd = "docker exec -i -t `#{docker_ps_cmd(target.family)}` #{command}"
         info "Executing #{command} on running container at #{ip}..."
 
-        system_exec(Broadside.config.ssh_cmd(ip, tty: command == BASH) + " '#{cmd}'")
+        system_exec(Broadside.config.ssh_cmd(ip, tty: true) + " '#{cmd}'")
       end
 
       private

--- a/lib/broadside/command.rb
+++ b/lib/broadside/command.rb
@@ -1,3 +1,4 @@
+require 'open3'
 require 'pp'
 require 'shellwords'
 require 'tty-table'
@@ -120,7 +121,11 @@ module Broadside
 
         ips.each do |ip|
           info "Executing '#{command}' on running container at #{ip}..."
-          puts %x[#{Broadside.config.ssh_cmd(ip, tty: true) + " '#{cmd}'"}]
+
+          Open3.popen3(Broadside.config.ssh_cmd(ip, tty: true) + " '#{cmd}'") do |_, stdout, stderr, _|
+            puts stdout.read
+            puts stderr.read
+          end
         end
       end
 

--- a/lib/broadside/gli/commands.rb
+++ b/lib/broadside/gli/commands.rb
@@ -97,7 +97,7 @@ command :bash do |bash|
 
   bash.desc 'bash command to run (wrap argument in quotes)'
   bash.arg_name 'BASH_COMMAND'
-  bash.flag [:c, :command], type: Array
+  bash.flag [:c, :command], type: String
 
   bash.action do |_, options, _|
     Broadside::Command.bash(options)

--- a/lib/broadside/gli/commands.rb
+++ b/lib/broadside/gli/commands.rb
@@ -99,6 +99,10 @@ command :bash do |bash|
   bash.arg_name 'BASH_COMMAND'
   bash.flag [:c, :command], type: String
 
+  bash.desc 'run on all containers in series'
+  bash.arg_name 'ALL_CONTAINERS'
+  bash.switch :all, negatable: false
+
   bash.action do |_, options, _|
     Broadside::Command.bash(options)
   end

--- a/lib/broadside/gli/commands.rb
+++ b/lib/broadside/gli/commands.rb
@@ -91,20 +91,29 @@ command :ssh do |ssh|
   end
 end
 
-desc 'Establish a shell or run a bash command inside a running container.'
+desc 'Establish a shell inside a running container.'
 command :bash do |bash|
   add_command_flags(bash)
 
-  bash.desc 'bash command to run (wrap argument in quotes)'
-  bash.arg_name 'BASH_COMMAND'
-  bash.flag [:c, :command], type: String
-
-  bash.desc 'run on all containers in series'
-  bash.arg_name 'ALL_CONTAINERS'
-  bash.switch :all, negatable: false
-
   bash.action do |_, options, _|
     Broadside::Command.bash(options)
+  end
+end
+
+desc 'Execute a bash command inside a running container.'
+command :execute do |execute|
+  add_command_flags(execute)
+
+  execute.desc 'bash command to run (wrap argument in quotes)'
+  execute.arg_name 'BASH_COMMAND'
+  execute.flag [:c, :command], type: String, required: true
+
+  execute.desc 'run on all containers in series'
+  execute.arg_name 'ALL_CONTAINERS'
+  execute.switch :all, negatable: false
+
+  execute.action do |_, options, _|
+    Broadside::Command.execute(options)
   end
 end
 

--- a/lib/broadside/version.rb
+++ b/lib/broadside/version.rb
@@ -1,3 +1,3 @@
 module Broadside
-  VERSION = '3.2.0'.freeze
+  VERSION = '3.2.1'.freeze
 end

--- a/lib/broadside/version.rb
+++ b/lib/broadside/version.rb
@@ -1,3 +1,3 @@
 module Broadside
-  VERSION = '3.2.1'.freeze
+  VERSION = '3.3.0'.freeze
 end

--- a/spec/broadside/command_spec.rb
+++ b/spec/broadside/command_spec.rb
@@ -54,13 +54,13 @@ describe Broadside::Command do
         end
 
         it 'executes correct bash command' do
-          expect(described_class).to receive(:"%x").with("#{docker_cmd} bash'")
+          expect(Open3).to receive(:popen3).with("#{docker_cmd} bash'")
           expect { described_class.bash(deploy_config) }.to_not raise_error
           expect(api_request_log).to eq(request_log)
         end
 
         it 'executes correct bash command' do
-          expect(described_class).to receive(:"%x").with("#{docker_cmd} ls'")
+          expect(Open3).to receive(:popen3).with("#{docker_cmd} ls'")
           expect { described_class.bash(deploy_config.merge(command: 'ls')) }.to_not raise_error
           expect(api_request_log).to eq(request_log)
         end

--- a/spec/broadside/command_spec.rb
+++ b/spec/broadside/command_spec.rb
@@ -54,13 +54,13 @@ describe Broadside::Command do
         end
 
         it 'executes correct bash command' do
-          expect(described_class).to receive(:exec).with("#{docker_cmd} bash'")
+          expect(described_class).to receive(:"%x").with("#{docker_cmd} bash'")
           expect { described_class.bash(deploy_config) }.to_not raise_error
           expect(api_request_log).to eq(request_log)
         end
 
         it 'executes correct bash command' do
-          expect(described_class).to receive(:exec).with("#{docker_cmd} ls'")
+          expect(described_class).to receive(:"%x").with("#{docker_cmd} ls'")
           expect { described_class.bash(deploy_config.merge(command: 'ls')) }.to_not raise_error
           expect(api_request_log).to eq(request_log)
         end

--- a/spec/broadside/command_spec.rb
+++ b/spec/broadside/command_spec.rb
@@ -28,7 +28,7 @@ describe Broadside::Command do
         let(:container_arn) { 'some_container_arn' }
         let(:instance_id) { 'i-xxxxxxxx' }
         let(:ip) { '123.123.123.123' }
-        let(:docker_cmd) { "#{user}@#{ip} 'docker exec -i -t `docker ps -n 1 --quiet --filter name=#{family}`" }
+        let(:docker_cmd) { "ssh -o StrictHostKeyChecking=no -t -t #{user}@#{ip} 'docker exec -i -t `docker ps -n 1 --quiet --filter name=#{family}`" }
         let(:request_log) do
           [
             { list_task_definitions: { family_prefix: family } },
@@ -54,13 +54,13 @@ describe Broadside::Command do
         end
 
         it 'executes correct bash command' do
-          expect(described_class).to receive(:exec).with("ssh -o StrictHostKeyChecking=no -t -t #{docker_cmd} bash'")
+          expect(described_class).to receive(:exec).with("#{docker_cmd} bash'")
           expect { described_class.bash(deploy_config) }.to_not raise_error
           expect(api_request_log).to eq(request_log)
         end
 
         it 'executes correct bash command' do
-          expect(described_class).to receive(:exec).with("ssh -o StrictHostKeyChecking=no #{docker_cmd} ls'")
+          expect(described_class).to receive(:exec).with("#{docker_cmd} ls'")
           expect { described_class.bash(deploy_config.merge(command: 'ls')) }.to_not raise_error
           expect(api_request_log).to eq(request_log)
         end

--- a/spec/broadside/command_spec.rb
+++ b/spec/broadside/command_spec.rb
@@ -53,16 +53,26 @@ describe Broadside::Command do
           end.to raise_error(Broadside::Error, /There are only 1 instances; index 2 does not exist/)
         end
 
-        it 'executes correct bash command' do
-          expect(Open3).to receive(:popen3).with("#{docker_cmd} bash'")
+        it 'executes bash' do
+          expect(described_class).to receive(:exec).with("#{docker_cmd} bash'")
           expect { described_class.bash(deploy_config) }.to_not raise_error
           expect(api_request_log).to eq(request_log)
         end
 
-        it 'executes correct bash command' do
-          expect(Open3).to receive(:popen3).with("#{docker_cmd} ls'")
-          expect { described_class.bash(deploy_config.merge(command: 'ls')) }.to_not raise_error
-          expect(api_request_log).to eq(request_log)
+        context '#execute' do
+          let(:command) { 'ls' }
+
+          it 'executes correct bash command' do
+            expect(Open3).to receive(:popen3).with("#{docker_cmd} #{command}'")
+            expect { described_class.execute(deploy_config.merge(command: 'ls')) }.to_not raise_error
+            expect(api_request_log).to eq(request_log)
+          end
+
+          it 'executes correct bash with the :all switch' do
+            expect(Open3).to receive(:popen3).with("#{docker_cmd} #{command}'")
+            expect { described_class.execute(deploy_config.merge(command: 'ls', all: true)) }.to_not raise_error
+            expect(api_request_log).to eq(request_log)
+          end
         end
       end
     end


### PR DESCRIPTION
I decided that having the `--command` flag on the `bash` command made the situation more complicated than it should be, especially when introducing the `--all` switch, so i separated `execute` to its own command namespace.  I think it's better this way.

Also addresses a bug where `Open3` would block an interactive session (bug is on master but was not released)