### PR TITLE
use new aws-sdk gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.3.1
+- Use new modularized aws-sdk gems: aws-sdk-ec2 & aws-sdk-ecs
+
 # 3.3.0
 - Add `execute` command to execute arbitrary bash inside a running container
 - Add `--all` flag to `execute` to run a command on all containers

--- a/broadside.gemspec
+++ b/broadside.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '>= 3', '< 6'
   spec.add_dependency 'activemodel', '>= 3', '< 6'
-  spec.add_dependency 'aws-sdk-ecs', '~> 1'
-  spec.add_dependency 'aws-sdk-ec2', '~> 1'
+  spec.add_dependency 'aws-sdk-ecs', '~> 1.0'
+  spec.add_dependency 'aws-sdk-ec2', '~> 1.0'
   spec.add_dependency 'dotenv', '>= 0.9.0', '< 3.0'
   spec.add_dependency 'gli', '~> 2.13'
   spec.add_dependency 'tty', '~> 0.5'

--- a/broadside.gemspec
+++ b/broadside.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '>= 3', '< 6'
   spec.add_dependency 'activemodel', '>= 3', '< 6'
-  spec.add_dependency 'aws-sdk', '~> 2.3'
+  spec.add_dependency 'aws-sdk-ecs', '~> 1'
+  spec.add_dependency 'aws-sdk-ec2', '~> 1'
   spec.add_dependency 'dotenv', '>= 0.9.0', '< 3.0'
   spec.add_dependency 'gli', '~> 2.13'
   spec.add_dependency 'tty', '~> 0.5'

--- a/lib/broadside.rb
+++ b/lib/broadside.rb
@@ -1,6 +1,7 @@
 require 'active_model'
 require 'active_support/core_ext'
-require 'aws-sdk'
+require 'aws-sdk-ec2'
+require 'aws-sdk-ecs'
 
 require 'broadside/error'
 require 'broadside/logging_utils'

--- a/lib/broadside/version.rb
+++ b/lib/broadside/version.rb
@@ -1,3 +1,3 @@
 module Broadside
-  VERSION = '3.3.0'.freeze
+  VERSION = '3.3.1'.freeze
 end


### PR DESCRIPTION
AWS has updated their ruby sdk to be modularized. This updates broadside to only use what it needs.