### PR TITLE
Fix parameter validator found 2 errors from :registered_at and :regis…

### DIFF
--- a/lib/broadside/ecs/ecs_manager.rb
+++ b/lib/broadside/ecs/ecs_manager.rb
@@ -35,7 +35,7 @@ module Broadside
 
       def get_latest_task_definition(name)
         return nil unless (arn = get_latest_task_definition_arn(name))
-        ecs.describe_task_definition(task_definition: arn).task_definition.to_h
+        ecs.describe_task_definition(task_definition: arn).task_definition.to_h.reject {|k, _v| k == :registered_at || k == :registered_by }
       end
 
       def get_latest_task_definition_arn(name)


### PR DESCRIPTION
```
I, [2021-07-22_10:04:26#87320]  INFO -- : [Aws::ECS::Client 200 0.074061 0 retries] describe_task_definition(task_definition:"arn:aws:ecs:us-east-1:914746133600:task-definition/kith-staging_worker:738")
error: parameter validator found 2 errors:
  - unexpected value at params[:registered_at]
  - unexpected value at params[:registered_by]
```

https://github.com/aws/aws-sdk/issues/38